### PR TITLE
[FEAT] Presigned URL 발급 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,22 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // OpenFeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // Swagger (SpringDoc)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
+}
+
+ext {
+    set('springCloudVersion', "2025.0.0")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 jib {

--- a/src/main/java/org/sopt/poti/PotiApplication.java
+++ b/src/main/java/org/sopt/poti/PotiApplication.java
@@ -2,9 +2,11 @@ package org.sopt.poti;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableFeignClients
 @SpringBootApplication
 public class PotiApplication {
 

--- a/src/main/java/org/sopt/poti/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/poti/domain/auth/controller/AuthController.java
@@ -1,0 +1,34 @@
+package org.sopt.poti.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.auth.dto.request.AuthRequest;
+import org.sopt.poti.domain.auth.dto.response.AuthResponse;
+import org.sopt.poti.domain.auth.service.AuthService;
+import org.sopt.poti.global.common.ApiResponse;
+import org.sopt.poti.global.common.SuccessStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+@Tag(name = "Auth", description = "인증 관련 API")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    @ResponseStatus(HttpStatus.OK) // 200 OK
+    @Operation(summary = "소셜 로그인/회원가입", description = "카카오 소셜 로그인을 수행하고 액세스/리프레시 토큰을 발급합니다.")
+    public ApiResponse<AuthResponse> socialLogin(@RequestBody @Valid AuthRequest request) {
+        AuthResponse response = authService.socialLogin(request);
+        return ApiResponse.success(SuccessStatus.OK, response);
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/auth/dto/request/AuthRequest.java
+++ b/src/main/java/org/sopt/poti/domain/auth/dto/request/AuthRequest.java
@@ -1,13 +1,14 @@
 package org.sopt.poti.domain.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.sopt.poti.domain.user.entity.SocialType;
 
 public record AuthRequest(
-    @NotBlank(message = "소셜 타입은 필수입니다.")
-    String socialType, // Enum 매핑 전 String으로 받아서 검증
-
+    @NotNull(message = "소셜 타입은 필수입니다.")
+    SocialType socialType,
+    
     @NotBlank(message = "토큰은 필수입니다.")
     String token
 ) {
-
 }

--- a/src/main/java/org/sopt/poti/domain/auth/dto/request/AuthRequest.java
+++ b/src/main/java/org/sopt/poti/domain/auth/dto/request/AuthRequest.java
@@ -1,0 +1,13 @@
+package org.sopt.poti.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthRequest(
+    @NotBlank(message = "소셜 타입은 필수입니다.")
+    String socialType, // Enum 매핑 전 String으로 받아서 검증
+
+    @NotBlank(message = "토큰은 필수입니다.")
+    String token
+) {
+
+}

--- a/src/main/java/org/sopt/poti/domain/auth/dto/response/AuthResponse.java
+++ b/src/main/java/org/sopt/poti/domain/auth/dto/response/AuthResponse.java
@@ -1,0 +1,12 @@
+package org.sopt.poti.domain.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AuthResponse(
+    String accessToken,
+    String refreshToken,
+    boolean isNewUser,
+    Long userId
+) {
+}

--- a/src/main/java/org/sopt/poti/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/org/sopt/poti/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,28 @@
+package org.sopt.poti.domain.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@RedisHash(value = "refreshToken")
+@AllArgsConstructor
+@Getter
+@Builder
+public class RefreshToken {
+
+    @Id
+    private Long userId; // Redis Key: refreshToken:{userId}
+
+    private String refreshToken;
+
+    @TimeToLive
+    private Long ttl; // 만료 시간 (초 단위)
+
+    public void updateRefreshToken(String refreshToken, Long ttl) {
+        this.refreshToken = refreshToken;
+        this.ttl = ttl;
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/sopt/poti/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.poti.domain.auth.repository;
+
+import org.sopt.poti.domain.auth.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+    
+}

--- a/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package org.sopt.poti.domain.auth.service;
 
+import feign.FeignException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +36,9 @@ public class AuthService {
 
   @Transactional
   public AuthResponse socialLogin(AuthRequest request) {
-    SocialType socialType = SocialType.valueOf(request.socialType().toUpperCase());
+    if (request.socialType() != SocialType.KAKAO) {
+      throw new BusinessException(ErrorStatus.INVALID_SOCIAL_TYPE);
+    }
 
     KakaoUserResponse kakaoUserResponse = getKakaoUserResponse(request.token());
     String socialId = String.valueOf(kakaoUserResponse.getId());
@@ -43,12 +46,13 @@ public class AuthService {
     boolean isNewUser;
     User user;
 
-    Optional<User> existingUser = userRepository.findBySocialIdAndSocialType(socialId, socialType);
+    Optional<User> existingUser = userRepository.findBySocialIdAndSocialType(socialId,
+        request.socialType());
 
     if (existingUser.isPresent()) {
       user = existingUser.get();
-      isNewUser = false;
-      
+      // 기존 유저이지만, 닉네임이 없으면 온보딩이 필요함
+      isNewUser = (user.getNickname() == null);
     } else {
       KakaoUserResponse.KakaoAccount kakaoAccount = kakaoUserResponse.getKakaoAccount();
       String email = null;
@@ -67,10 +71,10 @@ public class AuthService {
       // 회원가입 (신규 유저)
       user = User.createSocialUser(
           socialId,
-          socialType,
+          request.socialType(),
           email,
           nickname,
-          profileImageUrl,  // 있으면 쓰고 없으면 안쓰기
+          profileImageUrl,
           null // favoriteArtist는 신규 가입 시점에 null
       );
       userRepository.save(user);
@@ -100,10 +104,15 @@ public class AuthService {
   private KakaoUserResponse getKakaoUserResponse(String kakaoAccessToken) {
     try {
       return kakaoFeignClient.getUserInfo("Bearer " + kakaoAccessToken);
-    } catch (Exception e) { // FeignClient 호출 중 발생하는 모든 예외 처리
-
-      log.error("Kakao Login 실패: {}", e.getMessage());
-      throw new BusinessException(ErrorStatus.INVALID_TOKEN); // 카카오 토큰 에러 시
+    } catch (FeignException.Unauthorized | FeignException.Forbidden e) {
+      log.warn("Kakao 토큰 인증 실패: {}", e.getMessage());
+      throw new BusinessException(ErrorStatus.INVALID_TOKEN);
+    } catch (FeignException e) {
+      log.error("Kakao API 호출 실패 (status={}): {}", e.status(), e.getMessage());
+      throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
+    } catch (Exception e) {
+      log.error("Kakao Login 내부 오류: {}", e.getMessage());
+      throw new BusinessException(ErrorStatus.INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
@@ -1,0 +1,109 @@
+package org.sopt.poti.domain.auth.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.poti.domain.auth.dto.request.AuthRequest;
+import org.sopt.poti.domain.auth.dto.response.AuthResponse;
+import org.sopt.poti.domain.auth.entity.RefreshToken;
+import org.sopt.poti.domain.auth.repository.RefreshTokenRepository;
+import org.sopt.poti.domain.user.entity.SocialType;
+import org.sopt.poti.domain.user.entity.User;
+import org.sopt.poti.domain.user.repository.UserRepository;
+import org.sopt.poti.global.error.BusinessException;
+import org.sopt.poti.global.error.ErrorStatus;
+import org.sopt.poti.global.external.kakao.KakaoFeignClient;
+import org.sopt.poti.global.external.kakao.dto.KakaoUserResponse;
+import org.sopt.poti.global.security.jwt.JwtTokenProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class AuthService {
+
+  private final UserRepository userRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final KakaoFeignClient kakaoFeignClient; // FeignClient 주입
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  @Value("${jwt.refresh-token-validity}")
+  private long refreshTokenValidity;
+
+  @Transactional
+  public AuthResponse socialLogin(AuthRequest request) {
+    SocialType socialType = SocialType.valueOf(request.socialType().toUpperCase());
+
+    KakaoUserResponse kakaoUserResponse = getKakaoUserResponse(request.token());
+    String socialId = String.valueOf(kakaoUserResponse.getId());
+
+    boolean isNewUser;
+    User user;
+
+    Optional<User> existingUser = userRepository.findBySocialIdAndSocialType(socialId, socialType);
+
+    if (existingUser.isPresent()) {
+      user = existingUser.get();
+      isNewUser = false;
+      
+    } else {
+      KakaoUserResponse.KakaoAccount kakaoAccount = kakaoUserResponse.getKakaoAccount();
+      String email = null;
+      String nickname = null;
+      String profileImageUrl = null;
+
+      if (kakaoAccount != null) {
+        email = kakaoAccount.getEmail();
+        KakaoUserResponse.Profile profile = kakaoAccount.getProfile();
+        if (profile != null) {
+          nickname = profile.getNickname();
+          profileImageUrl = profile.getProfileImageUrl();
+        }
+      }
+
+      // 회원가입 (신규 유저)
+      user = User.createSocialUser(
+          socialId,
+          socialType,
+          email,
+          nickname,
+          profileImageUrl,  // 있으면 쓰고 없으면 안쓰기
+          null // favoriteArtist는 신규 가입 시점에 null
+      );
+      userRepository.save(user);
+      isNewUser = true;
+    }
+
+    user.updateLastActiveAt(); // 최종 로그인 시각 업데이트
+
+    String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+    String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+    // Redis에 Refresh Token 저장
+    refreshTokenRepository.save(RefreshToken.builder()
+        .userId(user.getId())
+        .refreshToken(refreshToken)
+        .ttl(refreshTokenValidity / 1000) // ms -> s 변환
+        .build());
+
+    return AuthResponse.builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .isNewUser(isNewUser)
+        .userId(user.getId())
+        .build();
+  }
+
+  private KakaoUserResponse getKakaoUserResponse(String kakaoAccessToken) {
+    try {
+      return kakaoFeignClient.getUserInfo("Bearer " + kakaoAccessToken);
+    } catch (Exception e) { // FeignClient 호출 중 발생하는 모든 예외 처리
+
+      log.error("Kakao Login 실패: {}", e.getMessage());
+      throw new BusinessException(ErrorStatus.INVALID_TOKEN); // 카카오 토큰 에러 시
+    }
+  }
+}

--- a/src/main/java/org/sopt/poti/domain/image/controller/ImageController.java
+++ b/src/main/java/org/sopt/poti/domain/image/controller/ImageController.java
@@ -1,0 +1,38 @@
+package org.sopt.poti.domain.image.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.image.dto.request.PresignedUrlRequest;
+import org.sopt.poti.domain.image.dto.response.PresignedUrlResponse;
+import org.sopt.poti.global.common.ApiResponse;
+import org.sopt.poti.global.common.SuccessStatus;
+import org.sopt.poti.global.external.s3.S3Service;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/images")
+@RequiredArgsConstructor
+@Tag(name = "Image", description = "이미지 업로드 관련 API")
+public class ImageController {
+
+  private final S3Service s3Service;
+
+  @GetMapping("/presigned-url")
+  @Operation(summary = "Presigned URL 다중 발급", description = "S3에 이미지를 업로드하기 위한 Presigned URL을 요청 수(count)만큼 발급받습니다.")
+  public ApiResponse<List<PresignedUrlResponse>> getPresignedUrl(
+      @ModelAttribute @Valid PresignedUrlRequest request
+  ) {
+    List<PresignedUrlResponse> response = s3Service.getPresignedUrls(
+        request.type(),
+        request.count(),
+        request.extension()
+    );
+    return ApiResponse.success(SuccessStatus.OK, response);
+  }
+}

--- a/src/main/java/org/sopt/poti/domain/image/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/org/sopt/poti/domain/image/dto/request/PresignedUrlRequest.java
@@ -1,0 +1,20 @@
+package org.sopt.poti.domain.image.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.sopt.poti.domain.image.entity.ImageDirectory;
+
+public record PresignedUrlRequest(
+    @NotNull(message = "이미지 용도(type)는 필수입니다.")
+    ImageDirectory type,
+
+    @Min(value = 1, message = "이미지 개수는 1개 이상이어야 합니다.")
+    @Max(value = 5, message = "이미지 개수는 5개 이하여야 합니다.")
+    int count,
+    
+    @NotBlank(message = "파일 확장자는 필수입니다.")
+    String extension
+) {
+}

--- a/src/main/java/org/sopt/poti/domain/image/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/org/sopt/poti/domain/image/dto/request/PresignedUrlRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import org.sopt.poti.domain.image.entity.ImageDirectory;
 
 public record PresignedUrlRequest(
@@ -15,6 +16,7 @@ public record PresignedUrlRequest(
     int count,
     
     @NotBlank(message = "파일 확장자는 필수입니다.")
+    @Pattern(regexp = "^(jpg|jpeg|png|heic|webp)$", message = "지원하지 않는 확장자입니다.")
     String extension
 ) {
 }

--- a/src/main/java/org/sopt/poti/domain/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/org/sopt/poti/domain/image/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.poti.domain.image.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record PresignedUrlResponse(
+    String fileName, // DB 저장용 경로 (Key)
+    String url       // 업로드용 URL
+) {
+    public static PresignedUrlResponse of(String fileName, String url) {
+        return PresignedUrlResponse.builder()
+                .fileName(fileName)
+                .url(url)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/image/entity/ImageDirectory.java
+++ b/src/main/java/org/sopt/poti/domain/image/entity/ImageDirectory.java
@@ -1,0 +1,14 @@
+package org.sopt.poti.domain.image.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageDirectory {
+  POST("posts"),
+  PROFILE("profiles"),
+  REVIEW("reviews");  // 아직 사진 리뷰는 없지만, 미리 추가
+
+  private final String prefix;
+}

--- a/src/main/java/org/sopt/poti/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/poti/domain/user/entity/User.java
@@ -1,9 +1,18 @@
 package org.sopt.poti.domain.user.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,56 +23,70 @@ import org.sopt.poti.global.entity.BaseTimeEntity;
 @Entity
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE) // @Builder 사용을 위한 추가
-@Builder // 빌더 패턴 사용을 위한 추가
 public class User extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Column(length = 255) // unique = true 제거 (socialId로 유니크 보장)
-    private String email;
+  @Column(length = 255)
+  private String email;
 
-    @Column(name = "social_id", length = 255, unique = true, nullable = false)
-    private String socialId;
+  @Column(name = "social_id", length = 255, unique = true, nullable = false)
+  private String socialId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "social_type", nullable = false)
-    private SocialType socialType;
+  @Enumerated(EnumType.STRING)
+  @Column(name = "social_type", nullable = false)
+  private SocialType socialType;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "role", nullable = false)
-    private Role role;
+  @Enumerated(EnumType.STRING)
+  @Column(name = "role", nullable = false)
+  private Role role;
 
-    @Column(length = 30)
-    private String nickname;
+  @Column(length = 30)
+  private String nickname;
 
-    @Column(name = "profile_image_url", length = 255)
-    private String profileImageUrl;
+  @Column(name = "profile_image_url", length = 255)
+  private String profileImageUrl;
 
-    @Column(name = "last_active_at")
-    private LocalDateTime lastActiveAt;
+  @Column(name = "last_active_at")
+  private LocalDateTime lastActiveAt;
 
-    @Column(name = "rating_avg")
-    private Double ratingAvg;
+  @Column(name = "rating_avg")
+  private Double ratingAvg;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "favorite_artist_id", nullable = false)
-    private Artist favoriteArtist;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "favorite_artist_id")
+  private Artist favoriteArtist;
 
-    // 소셜 로그인으로 사용자 생성 시 사용하는 빌더 메서드
-    public static User createSocialUser(String socialId, SocialType socialType, String email, String nickname, String profileImageUrl, Artist favoriteArtist) {
-        return User.builder()
-                .socialId(socialId)
-                .socialType(socialType)
-                .email(email)
-                .nickname(nickname)
-                .profileImageUrl(profileImageUrl)
-                .favoriteArtist(favoriteArtist)
-                .role(Role.USER) // 기본값으로 USER 설정
-                .ratingAvg(0.0)
-                .lastActiveAt(LocalDateTime.now())
-                .build();
-    }
+  @Builder
+  private User(String socialId, SocialType socialType, String email, String nickname,
+      String profileImageUrl, Artist favoriteArtist, Role role) {
+    this.socialId = socialId;
+    this.socialType = socialType;
+    this.email = email;
+    this.nickname = nickname;
+    this.profileImageUrl = profileImageUrl;
+    this.favoriteArtist = favoriteArtist;
+    this.role = role;
+    this.ratingAvg = 0.0;
+    this.lastActiveAt = LocalDateTime.now();
+  }
+
+  public static User createSocialUser(String socialId, SocialType socialType, String email,
+      String nickname, String profileImageUrl, Artist favoriteArtist) {
+    return User.builder()
+        .socialId(socialId)
+        .socialType(socialType)
+        .email(email)
+        .nickname(nickname)
+        .profileImageUrl(profileImageUrl)
+        .favoriteArtist(favoriteArtist)
+        .role(Role.USER)
+        .build();
+  }
+
+  public void updateLastActiveAt() {
+    this.lastActiveAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/sopt/poti/domain/user/repository/UserRepository.java
@@ -1,10 +1,12 @@
 package org.sopt.poti.domain.user.repository;
 
+import java.util.Optional;
+import org.sopt.poti.domain.user.entity.SocialType;
 import org.sopt.poti.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-
+    Optional<User> findBySocialIdAndSocialType(String socialId, SocialType socialType);
 }

--- a/src/main/java/org/sopt/poti/global/common/ApiResponse.java
+++ b/src/main/java/org/sopt/poti/global/common/ApiResponse.java
@@ -37,4 +37,12 @@ public record ApiResponse<T>(int code, String msg, T data) {
         null
     );
   }
+
+  public static <T> ApiResponse<T> fail(ErrorStatus status, String message) {
+    return new ApiResponse<>(
+        status.getCode(),
+        message,
+        null
+    );
+  }
 }

--- a/src/main/java/org/sopt/poti/global/config/S3Config.java
+++ b/src/main/java/org/sopt/poti/global/config/S3Config.java
@@ -20,7 +20,7 @@ public class S3Config {
     @Value("${spring.cloud.aws.region.static}")
     private String region;
 
-    @Bean
+    @Bean(destroyMethod = "close")
     public S3Presigner s3Presigner() {
         return S3Presigner.builder()
                 .region(Region.of(region))

--- a/src/main/java/org/sopt/poti/global/config/S3Config.java
+++ b/src/main/java/org/sopt/poti/global/config/S3Config.java
@@ -1,0 +1,30 @@
+package org.sopt.poti.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/poti/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/poti/global/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package org.sopt.poti.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "authorization";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .name(SECURITY_SCHEME_NAME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .info(new Info()
+                        .title("POTI Server API")
+                        .description("POTI 서비스 API 명세서")
+                        .version("1.0.0"));
+    }
+}

--- a/src/main/java/org/sopt/poti/global/dev/DevController.java
+++ b/src/main/java/org/sopt/poti/global/dev/DevController.java
@@ -1,5 +1,7 @@
 package org.sopt.poti.global.dev;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.user.entity.User;
 import org.sopt.poti.domain.user.repository.UserRepository;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/dev")
 @RequiredArgsConstructor
 @Profile({"local", "dev"})
+@Tag(name = "Dev", description = "개발자 테스트용 API")
 public class DevController {
 
   private final UserRepository userRepository;
@@ -25,18 +28,20 @@ public class DevController {
    * 개발자 테스트용 자동 로그인 (userId=1) 실제 서비스에서는 사용되지 않으며, 개발 단계에서 토큰 발급 편의를 위해 존재 DB에 id=1인 유저가 미리 존재해야 함
    */
   @GetMapping("/login")
+  @Operation(summary = "개발자용 토큰 발급 (userId=1)", description = "개발 테스트를 위해 1번 유저의 토큰을 즉시 발급합니다. (로컬/Dev 환경 전용)")
   public ResponseEntity<DevTokenResponseDto> devLogin() {
     // 개발자 테스트용 유저 ID (예: 1)
     Long devUserId = 1L;
 
-    // DB에서 유저 조회 (없으면 예외 발생)
+    // DB에서 유저 조회
     User user = userRepository.findById(devUserId)
         .orElseThrow(() -> new BusinessException(ErrorStatus.USER_NOT_FOUND));
 
     // Access Token 및 Refresh Token 생성
     String accessToken = jwtTokenProvider.createAccessToken(user.getId());
     String refreshToken = jwtTokenProvider.createRefreshToken(
-        user.getId()); // Refresh Token은 Redis에 저장하는 로직 필요 (이 컨트롤러에서는 생략)
+        user.getId()
+    );
 
     // 토큰 응답 DTO 생성
     DevTokenResponseDto responseDto = DevTokenResponseDto.builder()

--- a/src/main/java/org/sopt/poti/global/error/ErrorStatus.java
+++ b/src/main/java/org/sopt/poti/global/error/ErrorStatus.java
@@ -13,6 +13,7 @@ public enum ErrorStatus {
    * 400 Bad Request
    */
   BAD_REQUEST(40000, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+  INVALID_SOCIAL_TYPE(40001, HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다."),
 
   /**
    * 401 Unauthorized
@@ -35,11 +36,13 @@ public enum ErrorStatus {
    */
   USER_NOT_FOUND(40400, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
   ITEM_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
+  NOT_FOUND_HANDLER(40402, HttpStatus.NOT_FOUND, "존재하지 않는 API 경로입니다."),
 
   /**
    * 500 Internal Server Error
    */
-  INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+  INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+  EXTERNAL_API_ERROR(50001, HttpStatus.INTERNAL_SERVER_ERROR, "외부 API 호출 중 오류가 발생했습니다.");
 
   private final int code;
   private final HttpStatus httpStatus;

--- a/src/main/java/org/sopt/poti/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/poti/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.sopt.poti.global.error;
 
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.poti.global.common.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -8,14 +9,16 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(
       MethodArgumentNotValidException e) {
-    // 유효성 검증 실패
+    log.error("유효성 검증 실패: {}", e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
         ApiResponse.fail(ErrorStatus.BAD_REQUEST)
     );
@@ -24,7 +27,16 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(NoHandlerFoundException.class)
   public ResponseEntity<ApiResponse<Void>> handleNoHandlerFoundException(
       NoHandlerFoundException e) {
-    // 없는 API URL 요청
+    log.error("존재하지 않는 경로 요청: {}", e.getRequestURL());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+        ApiResponse.fail(ErrorStatus.NOT_FOUND_HANDLER)
+    );
+  }
+
+  @ExceptionHandler(NoResourceFoundException.class) // 추가
+  public ResponseEntity<ApiResponse<Void>> handleNoResourceFoundException(
+      NoResourceFoundException e) {
+    log.error("존재하지 않는 리소스 요청: {}", e.getResourcePath());
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
         ApiResponse.fail(ErrorStatus.NOT_FOUND_HANDLER)
     );
@@ -33,7 +45,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(
       HttpMessageNotReadableException e) {
-    // JSON 파싱 오류 등
+    log.error("잘못된 요청 형식: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
         ApiResponse.fail(ErrorStatus.BAD_REQUEST)
     );
@@ -41,7 +53,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-    // 예외처리 못한 모든 Exception
+    log.error("예상치 못한 예외 발생: ", e); // 스택 트레이스 포함
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
         ApiResponse.fail(ErrorStatus.INTERNAL_SERVER_ERROR)
     );
@@ -49,7 +61,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(BusinessException.class)
   public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
-    // 커스텀 예외
+    log.error("비즈니스 예외 발생: {}", e.getErrorStatus().getMessage());
     return ResponseEntity.status(e.getErrorStatus().getHttpStatus()).body(
         ApiResponse.fail(e.getErrorStatus())
     );

--- a/src/main/java/org/sopt/poti/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/poti/global/error/GlobalExceptionHandler.java
@@ -18,9 +18,10 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(
       MethodArgumentNotValidException e) {
-    log.error("유효성 검증 실패: {}", e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+    String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+    log.error("유효성 검증 실패: {}", errorMessage);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-        ApiResponse.fail(ErrorStatus.BAD_REQUEST)
+        ApiResponse.fail(ErrorStatus.BAD_REQUEST, errorMessage)
     );
   }
 

--- a/src/main/java/org/sopt/poti/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/poti/global/error/GlobalExceptionHandler.java
@@ -33,7 +33,7 @@ public class GlobalExceptionHandler {
     );
   }
 
-  @ExceptionHandler(NoResourceFoundException.class) // 추가
+  @ExceptionHandler(NoResourceFoundException.class)
   public ResponseEntity<ApiResponse<Void>> handleNoResourceFoundException(
       NoResourceFoundException e) {
     log.error("존재하지 않는 리소스 요청: {}", e.getResourcePath());
@@ -53,7 +53,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-    log.error("예상치 못한 예외 발생: ", e); // 스택 트레이스 포함
+    log.error("예상치 못한 예외 발생: ", e);
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
         ApiResponse.fail(ErrorStatus.INTERNAL_SERVER_ERROR)
     );

--- a/src/main/java/org/sopt/poti/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/poti/global/error/GlobalExceptionHandler.java
@@ -3,15 +3,45 @@ package org.sopt.poti.global.error;
 import org.sopt.poti.global.common.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException e) {
+    // 유효성 검증 실패
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+        ApiResponse.fail(ErrorStatus.BAD_REQUEST)
+    );
+  }
+
+  @ExceptionHandler(NoHandlerFoundException.class)
+  public ResponseEntity<ApiResponse<Void>> handleNoHandlerFoundException(
+      NoHandlerFoundException e) {
+    // 없는 API URL 요청
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+        ApiResponse.fail(ErrorStatus.NOT_FOUND_HANDLER)
+    );
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(
+      HttpMessageNotReadableException e) {
+    // JSON 파싱 오류 등
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+        ApiResponse.fail(ErrorStatus.BAD_REQUEST)
+    );
+  }
+
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-
+    // 예외처리 못한 모든 Exception
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
         ApiResponse.fail(ErrorStatus.INTERNAL_SERVER_ERROR)
     );
@@ -19,7 +49,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(BusinessException.class)
   public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
-
+    // 커스텀 예외
     return ResponseEntity.status(e.getErrorStatus().getHttpStatus()).body(
         ApiResponse.fail(e.getErrorStatus())
     );

--- a/src/main/java/org/sopt/poti/global/external/kakao/KakaoFeignClient.java
+++ b/src/main/java/org/sopt/poti/global/external/kakao/KakaoFeignClient.java
@@ -1,0 +1,13 @@
+package org.sopt.poti.global.external.kakao;
+
+import org.sopt.poti.global.external.kakao.dto.KakaoUserResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakao-client", url = "https://kapi.kakao.com")
+public interface KakaoFeignClient {
+
+    @GetMapping("/v2/user/me")
+    KakaoUserResponse getUserInfo(@RequestHeader("Authorization") String accessToken);
+}

--- a/src/main/java/org/sopt/poti/global/external/kakao/dto/KakaoUserResponse.java
+++ b/src/main/java/org/sopt/poti/global/external/kakao/dto/KakaoUserResponse.java
@@ -1,0 +1,33 @@
+package org.sopt.poti.global.external.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserResponse {
+
+  private Long id;
+
+  @JsonProperty("kakao_account")
+  private KakaoAccount kakaoAccount;
+
+  @Getter
+  @NoArgsConstructor
+  public static class KakaoAccount {
+
+    private Profile profile;
+    private String email;
+  }
+
+  @Getter
+  @NoArgsConstructor
+  public static class Profile {
+
+    private String nickname;
+
+    @JsonProperty("profile_image_url")
+    private String profileImageUrl;
+  }
+}

--- a/src/main/java/org/sopt/poti/global/external/s3/S3Service.java
+++ b/src/main/java/org/sopt/poti/global/external/s3/S3Service.java
@@ -1,0 +1,62 @@
+package org.sopt.poti.global.external.s3;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.image.dto.response.PresignedUrlResponse;
+import org.sopt.poti.domain.image.entity.ImageDirectory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+  private final S3Presigner s3Presigner;
+
+  @Value("${spring.cloud.aws.s3.bucket}")
+  private String bucketName;
+
+  public List<PresignedUrlResponse> getPresignedUrls(ImageDirectory directory, int count,
+      String extension) {
+    List<PresignedUrlResponse> responses = new ArrayList<>();
+
+    // count 만큼 Presigned URL 발급을 위한 반복문
+    for (int i = 0; i < count; i++) {
+      String path = createPath(directory.getPrefix(), extension);
+      String presignedUrl = generatePresignedUrl(path);
+
+      responses.add(PresignedUrlResponse.of(path, presignedUrl));
+    }
+
+    return responses;
+  }
+
+  private String generatePresignedUrl(String key) {
+    PutObjectRequest objectRequest = PutObjectRequest.builder()
+        .bucket(bucketName)
+        .key(key)
+        .build();
+
+    PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+        .signatureDuration(Duration.ofMinutes(5)) // 5분간 유효
+        .putObjectRequest(objectRequest)
+        .build();
+
+    return s3Presigner.presignPutObject(presignRequest).url().toString();
+  }
+
+  private String createPath(String prefix, String extension) {
+    String fileId = UUID.randomUUID().toString();
+    LocalDate now = LocalDate.now();
+    // 예: posts/2026/01/uuid.jpg
+    return String.format("%s/%d/%02d/%s.%s",
+        prefix, now.getYear(), now.getMonthValue(), fileId, extension);
+  }
+}

--- a/src/main/java/org/sopt/poti/global/external/s3/S3Service.java
+++ b/src/main/java/org/sopt/poti/global/external/s3/S3Service.java
@@ -6,16 +6,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.poti.domain.image.dto.response.PresignedUrlResponse;
 import org.sopt.poti.domain.image.entity.ImageDirectory;
+import org.sopt.poti.global.error.BusinessException;
+import org.sopt.poti.global.error.ErrorStatus;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class S3Service {
 
   private final S3Presigner s3Presigner;
@@ -27,7 +32,6 @@ public class S3Service {
       String extension) {
     List<PresignedUrlResponse> responses = new ArrayList<>();
 
-    // count 만큼 Presigned URL 발급을 위한 반복문
     for (int i = 0; i < count; i++) {
       String path = createPath(directory.getPrefix(), extension);
       String presignedUrl = generatePresignedUrl(path);
@@ -39,17 +43,25 @@ public class S3Service {
   }
 
   private String generatePresignedUrl(String key) {
-    PutObjectRequest objectRequest = PutObjectRequest.builder()
-        .bucket(bucketName)
-        .key(key)
-        .build();
+    try {
+      PutObjectRequest objectRequest = PutObjectRequest.builder()
+          .bucket(bucketName)
+          .key(key)
+          .build();
 
-    PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
-        .signatureDuration(Duration.ofMinutes(5)) // 5분간 유효
-        .putObjectRequest(objectRequest)
-        .build();
+      PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+          .signatureDuration(Duration.ofMinutes(5)) // 5분간 유효
+          .putObjectRequest(objectRequest)
+          .build();
 
-    return s3Presigner.presignPutObject(presignRequest).url().toString();
+      return s3Presigner.presignPutObject(presignRequest).url().toString();
+    } catch (S3Exception e) {
+      log.error("S3 Presigned URL 생성 실패: {}", e.getMessage());
+      throw new BusinessException(ErrorStatus.EXTERNAL_API_ERROR);
+    } catch (Exception e) {
+      log.error("S3 Presigned URL 생성 중 알 수 없는 오류: {}", e.getMessage());
+      throw new BusinessException(ErrorStatus.INTERNAL_SERVER_ERROR);
+    }
   }
 
   private String createPath(String prefix, String extension) {

--- a/src/main/java/org/sopt/poti/global/external/s3/dto/PresignedUrlResponse.java
+++ b/src/main/java/org/sopt/poti/global/external/s3/dto/PresignedUrlResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.poti.global.external.s3.dto;
+
+public record PresignedUrlResponse(
+    String presignedUrl, // 업로드용 URL (PUT)
+    String imageUrl      // 조회/저장용 URL (DB에 저장할 값)
+) {
+    public static PresignedUrlResponse of(String presignedUrl, String imageUrl) {
+        return new PresignedUrlResponse(presignedUrl, imageUrl);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,12 @@ spring:
   application:
     name: poti-server
 
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
+
   # Database (MySQL)
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,12 +14,6 @@ spring:
   application:
     name: poti-server
 
-  mvc:
-    throw-exception-if-no-handler-found: true
-  web:
-    resources:
-      add-mappings: false
-
   # Database (MySQL)
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -26,6 +26,17 @@ spring:
       host: localhost
       port: 6379
 
+  # AWS S3 (테스트 환경용 더미 설정)
+  cloud:
+    aws:
+      credentials:
+        access-key: test-access-key
+        secret-key: test-secret-key
+      region:
+        static: ap-northeast-2 # S3Config에 설정된 리전과 일치
+      s3:
+        bucket: test-bucket
+
   # 테스트 환경에서는 JWT 설정값들을 임의로 지정 (환경변수 의존 제거)
 jwt:
   secret: dGVzdC1zZWNyZXQta2V5LWZvci1qcGEtdGVzdGluZy1wdXJwb3Nlcy1vbmx5LWRvLW5vdC11c2Ut


### PR DESCRIPTION
##  📌 관련 이슈
  <!-- 관련 이슈를 적어주세요. -->
   - close #22 

##  ✨ 변경 사항
  <!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
   - S3 Presigned URL 발급 API 구현
     - 클라이언트가 S3에 직접 이미지를 업로드할 수 있도록 Presigned URL을 발급하는 API를 구현했습니다.
     - ImageController: GET /api/v1/images/presigned-url 엔드포인트 추가.
     - S3Service: AWS SDK v2(S3Presigner)를 사용하여 URL 생성 로직 구현.
     - PresignedUrlRequest: 이미지 용도(type), 개수(count), 확장자(extension)를 받는 DTO 정의.
     - ImageDirectory Enum: 이미지 용도별(게시글, 프로필 등) 저장 경로(Prefix) 관리.
     - application.yml & .env: AWS 자격 증명 및 버킷 설정 추가.

##  📸 테스트 증명 (필수)
- Presigned URL 발급 확인
<img width="2080" height="1452" alt="image" src="https://github.com/user-attachments/assets/0fd2c99c-b137-4af3-be42-6ad18744fadb" />

- Presigned URL 정상 작동 확인
<img width="2092" height="1292" alt="image" src="https://github.com/user-attachments/assets/5f86acb9-a00d-4e6c-86df-6707ab719398" />

- 5개 초과 요청시 예외 처리 
- 0개 요청시 예외 처리
- 파라미터 없을 시 예외 처리

##  📚 리뷰어 참고 사항
  <!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
   - AWS SDK v2: spring-cloud-starter-aws 3.x 버전을 사용함에 따라 AmazonS3 대신 S3Presigner를 사용했습니다.
   - GET 방식: URL 조회 성격에 맞게 POST가 아닌 GET 방식을 사용했으며, 파라미터 바인딩을 위해 @ModelAttribute를 활용했습니다.
   - 파일 경로: 용도/년/월/UUID.확장자 형식으로 저장되어 관리 편의성을 높였습니다.

  ✅ 체크리스트
   - [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
   - [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
   - [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
   - [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 카카오 소셜 로그인(토큰 발급, 신규/기존 사용자 처리) 추가
  * 이미지 업로드용 S3 사전 서명 URL 일괄 생성 API 추가
  * OpenAPI/Swagger UI 기반 API 문서화 제공

* **Improvements**
  * 입력 유효성 검사 강화(인증·이미지 요청)
  * 리프레시 토큰 영속화 및 만료 관리(캐시/저장)
  * 외부 API 호출·오류 처리 및 전역 예외 로깅 개선
  * 개발자용 토큰 발급 API에 문서화 주석 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->