### PR TITLE
[FEAT] 공동구매 게시글 API 및 상품명 자동완성 구현

### DIFF
--- a/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepository.java
+++ b/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.poti.domain.artist.repository;
+
+import org.sopt.poti.domain.artist.entity.Artist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArtistRepository extends JpaRepository<Artist, Long> {
+}

--- a/src/main/java/org/sopt/poti/domain/artist/repository/MemberRepository.java
+++ b/src/main/java/org/sopt/poti/domain/artist/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.poti.domain.artist.repository;
+
+import org.sopt.poti.domain.artist.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/org/sopt/poti/domain/artist/service/ArtistService.java
+++ b/src/main/java/org/sopt/poti/domain/artist/service/ArtistService.java
@@ -1,0 +1,22 @@
+package org.sopt.poti.domain.artist.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.artist.entity.Artist;
+import org.sopt.poti.domain.artist.repository.ArtistRepository;
+import org.sopt.poti.global.error.BusinessException;
+import org.sopt.poti.global.error.ErrorStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArtistService {
+
+    private final ArtistRepository artistRepository;
+
+    public Artist getArtistById(Long artistId) {
+        return artistRepository.findById(artistId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.ARTIST_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/artist/service/MemberService.java
+++ b/src/main/java/org/sopt/poti/domain/artist/service/MemberService.java
@@ -1,0 +1,22 @@
+package org.sopt.poti.domain.artist.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.artist.entity.Member;
+import org.sopt.poti.domain.artist.repository.MemberRepository;
+import org.sopt.poti.global.error.BusinessException;
+import org.sopt.poti.global.error.ErrorStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/delivery/repository/DeliveryMethodRepository.java
+++ b/src/main/java/org/sopt/poti/domain/delivery/repository/DeliveryMethodRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.poti.domain.delivery.repository;
+
+import org.sopt.poti.domain.delivery.entity.DeliveryMethod;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DeliveryMethodRepository extends JpaRepository<DeliveryMethod, Long> {
+}

--- a/src/main/java/org/sopt/poti/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/org/sopt/poti/domain/delivery/service/DeliveryService.java
@@ -1,0 +1,22 @@
+package org.sopt.poti.domain.delivery.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.delivery.entity.DeliveryMethod;
+import org.sopt.poti.domain.delivery.repository.DeliveryMethodRepository;
+import org.sopt.poti.global.error.BusinessException;
+import org.sopt.poti.global.error.ErrorStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeliveryService {
+
+    private final DeliveryMethodRepository deliveryMethodRepository;
+
+    public DeliveryMethod getDeliveryMethodById(Long deliveryMethodId) {
+        return deliveryMethodRepository.findById(deliveryMethodId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.DELIVERY_METHOD_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
@@ -1,0 +1,55 @@
+package org.sopt.poti.domain.groupbuy.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyCreateRequest;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyCreateResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyTitlesResponse;
+import org.sopt.poti.domain.groupbuy.service.GroupBuyService;
+import org.sopt.poti.global.common.ApiResponse;
+import org.sopt.poti.global.common.SuccessStatus;
+import org.sopt.poti.global.security.UserPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/posts")
+@RequiredArgsConstructor
+@Tag(name = "GroupBuy", description = "공동구매 관련 API")
+public class GroupBuyController {
+
+  private final GroupBuyService groupBuyService;
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  @Operation(summary = "공동구매 게시글 등록", description = "새로운 공동구매 게시글을 등록합니다.")
+  public ApiResponse<GroupBuyCreateResponse> createGroupBuy(
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
+      @RequestBody @Valid GroupBuyCreateRequest request
+  ) {
+    GroupBuyCreateResponse response = groupBuyService.createGroupBuyPost(userPrincipal.getUserId(),
+        request);
+    return ApiResponse.success(SuccessStatus.CREATED, response);
+  }
+
+  @GetMapping("/titles")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(summary = "상품명 자동완성/추천", description = "입력 키워드를 기반으로 공동구매 상품명 리스트를 추천합니다.")
+  public ApiResponse<GroupBuyTitlesResponse> searchTitles(
+      @RequestParam Long artistId,
+      @RequestParam String keyword
+  ) {
+    List<String> titles = groupBuyService.searchTitles(artistId, keyword);
+    return ApiResponse.success(SuccessStatus.OK, GroupBuyTitlesResponse.of(titles));
+  }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyCreateRequest.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyCreateRequest.java
@@ -1,0 +1,63 @@
+package org.sopt.poti.domain.groupbuy.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDate;
+import java.util.List;
+
+public record GroupBuyCreateRequest(
+    @NotNull(message = "아티스트 ID는 필수입니다.")
+    Long artistId,
+
+    @NotBlank(message = "공구 제목은 필수입니다.")
+    String title,
+
+    @NotBlank(message = "상세 설명은 필수입니다.")
+    String content,
+
+    @NotNull(message = "모집 마감일은 필수입니다.")
+    @Future(message = "모집 마감일은 현재보다 미래여야 합니다.")
+    LocalDate deadline, // yyyy-MM-dd 형식
+
+    @NotBlank(message = "은행명은 필수입니다.")
+    String bankName,
+
+    @NotBlank(message = "계좌번호는 필수입니다.")
+    String accountNumber,
+
+    @NotEmpty(message = "이미지 경로는 최소 1개 이상 필수입니다.")
+    List<String> imageUrls, // S3 키값 리스트
+
+    @NotEmpty(message = "멤버 옵션은 최소 1개 이상 필수입니다.")
+    @Valid
+    List<OptionRequest> options,
+
+    @NotEmpty(message = "배송 방법은 최소 1개 이상 필수입니다.")
+    @Valid
+    List<ShippingRequest> shippings
+) {
+
+  public record OptionRequest(
+      @NotNull(message = "멤버 ID는 필수입니다.")
+      Long memberId,
+
+      @Positive(message = "가격은 양수여야 합니다.")
+      int price
+  ) {
+
+  }
+
+  public record ShippingRequest(
+      @NotNull(message = "배송 방법 ID는 필수입니다.")
+      Long deliveryMethodId,
+
+      @Positive(message = "배송비는 양수여야 합니다.")
+      int price
+  ) {
+
+  }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyCreateResponse.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyCreateResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.poti.domain.groupbuy.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record GroupBuyCreateResponse(
+    Long postId // 생성된 게시글 ID
+) {
+    public static GroupBuyCreateResponse of(Long postId) {
+        return GroupBuyCreateResponse.builder()
+                .postId(postId)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyTitlesResponse.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyTitlesResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.poti.domain.groupbuy.dto.response;
+
+import java.util.List;
+
+public record GroupBuyTitlesResponse(
+    List<String> titles
+) {
+    public static GroupBuyTitlesResponse of(List<String> titles) {
+        return new GroupBuyTitlesResponse(titles);
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyOption.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyOption.java
@@ -1,9 +1,19 @@
 package org.sopt.poti.domain.groupbuy.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.sopt.poti.domain.artist.entity.Member;
 
 @Getter
@@ -12,30 +22,34 @@ import org.sopt.poti.domain.artist.entity.Member;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupBuyOption {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Column(name = "option_name", nullable = false, length = 100)
-    private String optionName; // 멤버 명 (ex 레이, 유진)
+  @Column(nullable = false)
+  private int price;
 
-    @Column(nullable = false)
-    private int price;
+  @Setter
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "group_buy_post_id", nullable = false)
+  private GroupBuyPost groupBuyPost;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_buy_post_id", nullable = false)
-    private GroupBuyPost groupBuyPost;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+  @Builder
+  private GroupBuyOption(int price, GroupBuyPost groupBuyPost, Member member) {
+    this.price = price;
+    this.groupBuyPost = groupBuyPost;
+    this.member = member;
+  }
 
-    public static GroupBuyOption create(String optionName, int price, GroupBuyPost post, Member member) {
-        GroupBuyOption opt = new GroupBuyOption();
-        opt.optionName = optionName;
-        opt.price = price;
-        opt.groupBuyPost = post;
-        opt.member = member;
-        return opt;
-    }
+  public static GroupBuyOption create(int price, Member member) {
+    return GroupBuyOption.builder()
+        .price(price)
+        .member(member)
+        .build();
+  }
+
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
@@ -1,9 +1,21 @@
 package org.sopt.poti.domain.groupbuy.entity;
 
-import jakarta.persistence.*;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.time.LocalDate;
-
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,81 +30,104 @@ import org.sopt.poti.global.entity.BaseTimeEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupBuyPost extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Column(nullable = false, length = 200)
-    private String title;
+  @Column(nullable = false, length = 200)
+  private String title;
 
-    @Column(columnDefinition = "TEXT")
-    private String content;
+  @Column(columnDefinition = "TEXT")
+  private String content;
 
-    @Column(name = "recruit_deadline")
-    private LocalDate recruitDeadline;
+  @Column(name = "recruit_deadline", nullable = false) // 마감일 필수
+  private LocalDate recruitDeadline;
 
-    @Column(name = "bank_name", length = 50)
-    private String bankName;
+  @Column(name = "bank_name", length = 50, nullable = false) // 은행명 필수
+  private String bankName;
 
-    @Column(name = "account_number", length = 50)
-    private String accountNumber;
+  @Column(name = "account_number", length = 50, nullable = false) // 계좌번호 필수
+  private String accountNumber;
 
-    @Column(name = "account_holder", length = 50)
-    private String accountHolder;
+  @Column(name = "account_holder", length = 50)
+  private String accountHolder;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 30)
-    private GroupBuyPostStatus status;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 30)
+  private GroupBuyPostStatus status;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "leader_user_id", nullable = false)
-    private User leader; // 총대
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User leader; // 총대
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "artist_id", nullable = false)
-    private Artist artist;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "artist_id", nullable = false)
+  private Artist artist;
 
-    @Builder
-    private GroupBuyPost(
-            String title,
-            String content,
-            LocalDate recruitDeadline,
-            String bankName,
-            String accountNumber,
-            String accountHolder,
-            User leader,
-            Artist artist
-    ) {
-        this.title = title;
-        this.content = content;
-        this.recruitDeadline = recruitDeadline;
-        this.bankName = bankName;
-        this.accountNumber = accountNumber;
-        this.accountHolder = accountHolder;
-        this.leader = leader;
-        this.artist = artist;
-        this.status = GroupBuyPostStatus.RECRUITING;
-    }
+  @OneToMany(mappedBy = "groupBuyPost", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<GroupBuyOption> options = new ArrayList<>();
 
-    public static GroupBuyPost create(
-            String title,
-            String content,
-            LocalDate recruitDeadline,
-            String bankName,
-            String accountNumber,
-            String accountHolder,
-            User leader,
-            Artist artist
-    ) {
-        return GroupBuyPost.builder()
-                .title(title)
-                .content(content)
-                .recruitDeadline(recruitDeadline)
-                .bankName(bankName)
-                .accountNumber(accountNumber)
-                .accountHolder(accountHolder)
-                .leader(leader)
-                .artist(artist)
-                .build();
-    }
+  @OneToMany(mappedBy = "groupBuyPost", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<ItemImage> images = new ArrayList<>();
+
+  @OneToMany(mappedBy = "groupBuyPost", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<GroupBuyShipping> shippings = new ArrayList<>();
+
+  @Builder
+  private GroupBuyPost(
+      String title,
+      String content,
+      LocalDate recruitDeadline,
+      String bankName,
+      String accountNumber,
+      User leader,
+      Artist artist
+  ) {
+    this.title = title;
+    this.content = content;
+    this.recruitDeadline = recruitDeadline;
+    this.bankName = bankName;
+    this.accountNumber = accountNumber;
+    // this.accountHolder = accountHolder;
+    this.leader = leader;
+    this.artist = artist;
+    this.status = GroupBuyPostStatus.RECRUITING; // 초기 상태: 모집 중
+  }
+
+  public static GroupBuyPost create(
+      String title,
+      String content,
+      LocalDate recruitDeadline,
+      String bankName,
+      String accountNumber,
+      User leader,
+      Artist artist
+  ) {
+    return GroupBuyPost.builder()
+        .title(title)
+        .content(content)
+        .recruitDeadline(recruitDeadline)
+        .bankName(bankName)
+        .accountNumber(accountNumber)
+        // .accountHolder(accountHolder)
+        .leader(leader)
+        .artist(artist)
+        .build();
+  }
+
+  // 연관관계 편의 메서드
+  public void addOption(GroupBuyOption option) {
+    this.options.add(option);
+    option.setGroupBuyPost(this); // 양방향 연관관계 설정
+  }
+
+  public void addImage(ItemImage image) {
+    this.images.add(image);
+    image.setGroupBuyPost(this); // 양방향 연관관계 설정
+  }
+
+  public void addShipping(GroupBuyShipping shipping) {
+    this.shippings.add(shipping);
+    shipping.setGroupBuyPost(this); // 양방향 연관관계 설정
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyShipping.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyShipping.java
@@ -1,0 +1,57 @@
+package org.sopt.poti.domain.groupbuy.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.poti.domain.delivery.entity.DeliveryMethod;
+
+@Getter
+@Entity
+@Table(name = "group_buy_shippings")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupBuyShipping {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private int price; // 해당 공구에서의 배송비
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_buy_post_id", nullable = false)
+    private GroupBuyPost groupBuyPost;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "delivery_method_id", nullable = false)
+    private DeliveryMethod deliveryMethod;
+
+    @Builder
+    private GroupBuyShipping(int price, GroupBuyPost groupBuyPost, DeliveryMethod deliveryMethod) {
+        this.price = price;
+        this.groupBuyPost = groupBuyPost;
+        this.deliveryMethod = deliveryMethod;
+    }
+
+    public static GroupBuyShipping create(int price, DeliveryMethod deliveryMethod) {
+        return GroupBuyShipping.builder()
+                .price(price)
+                .deliveryMethod(deliveryMethod)
+                .build();
+    }
+
+    // 양방향 연관관계 편의 메서드
+    public void setGroupBuyPost(GroupBuyPost groupBuyPost) {
+        this.groupBuyPost = groupBuyPost;
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/ItemImage.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/ItemImage.java
@@ -1,9 +1,19 @@
 package org.sopt.poti.domain.groupbuy.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -11,25 +21,34 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ItemImage {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Column(name = "image_url", length = 255)
-    private String imageUrl;
+  @Column(name = "image_url", length = 255, nullable = false) // 이미지 URL은 필수
+  private String imageUrl;
 
-    @Column(name = "sort_order")
-    private Integer sortOrder;
+  @Column(name = "sort_order")
+  private Integer sortOrder;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_buy_post_id", nullable = false)
-    private GroupBuyPost groupBuyPost;
+  // 양방향 연관관계 편의 메서드
+  @Setter
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "group_buy_post_id", nullable = false)
+  private GroupBuyPost groupBuyPost;
 
-    public static ItemImage create(String imageUrl, Integer sortOrder, GroupBuyPost post) {
-        ItemImage img = new ItemImage();
-        img.imageUrl = imageUrl;
-        img.sortOrder = sortOrder;
-        img.groupBuyPost = post;
-        return img;
-    }
+  @Builder
+  private ItemImage(String imageUrl, Integer sortOrder, GroupBuyPost groupBuyPost) {
+    this.imageUrl = imageUrl;
+    this.sortOrder = sortOrder;
+    this.groupBuyPost = groupBuyPost;
+  }
+
+  public static ItemImage create(String imageUrl, Integer sortOrder) {
+    return ItemImage.builder()
+        .imageUrl(imageUrl)
+        .sortOrder(sortOrder)
+        .build();
+  }
+
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepository.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.poti.domain.groupbuy.repository;
+
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GroupBuyRepository extends JpaRepository<GroupBuyPost, Long>, GroupBuyRepositoryCustom {
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
@@ -1,0 +1,7 @@
+package org.sopt.poti.domain.groupbuy.repository;
+
+import java.util.List;
+
+public interface GroupBuyRepositoryCustom {
+    List<String> findTitlesByKeyword(Long artistId, String keyword, int limit);
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
@@ -1,0 +1,27 @@
+package org.sopt.poti.domain.groupbuy.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.groupbuy.entity.QGroupBuyPost;
+
+@RequiredArgsConstructor
+public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<String> findTitlesByKeyword(Long artistId, String keyword, int limit) {
+        QGroupBuyPost groupBuyPost = QGroupBuyPost.groupBuyPost;
+
+        return queryFactory
+                .selectDistinct(groupBuyPost.title)
+                .from(groupBuyPost)
+                .where(
+                        groupBuyPost.artist.id.eq(artistId),
+                        groupBuyPost.title.contains(keyword)
+                )
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -65,7 +65,7 @@ public class GroupBuyService {
       groupBuyPost.addShipping(shipping);
     });
 
-    // 4. 이미지 (ItemImage) 연결
+    // 이미지 (ItemImage) 연결
     List<String> imageUrls = request.imageUrls();
     for (int i = 0; i < imageUrls.size(); i++) {
       ItemImage image = ItemImage.create(imageUrls.get(i), i);

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -1,0 +1,86 @@
+package org.sopt.poti.domain.groupbuy.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.artist.entity.Artist;
+import org.sopt.poti.domain.artist.entity.Member;
+import org.sopt.poti.domain.artist.service.ArtistService;
+import org.sopt.poti.domain.artist.service.MemberService;
+import org.sopt.poti.domain.delivery.entity.DeliveryMethod;
+import org.sopt.poti.domain.delivery.service.DeliveryService;
+import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyCreateRequest;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyCreateResponse;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyOption;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyShipping;
+import org.sopt.poti.domain.groupbuy.entity.ItemImage;
+import org.sopt.poti.domain.groupbuy.repository.GroupBuyRepository;
+import org.sopt.poti.domain.user.entity.User;
+import org.sopt.poti.domain.user.service.UserService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GroupBuyService {
+
+  private final GroupBuyRepository groupBuyRepository;
+  private final UserService userService;
+  private final ArtistService artistService;
+  private final MemberService memberService;
+  private final DeliveryService deliveryService;
+
+  @Transactional
+  public GroupBuyCreateResponse createGroupBuyPost(Long userId, GroupBuyCreateRequest request) {
+    User leader = userService.getUserById(userId);
+
+    Artist artist = artistService.getArtistById(request.artistId());
+
+    // GroupBuyPost 엔티티 생성
+    GroupBuyPost groupBuyPost = GroupBuyPost.create(
+        request.title(),
+        request.content(),
+        request.deadline(),
+        request.bankName(),
+        request.accountNumber(),
+        leader,
+        artist
+    );
+
+    // 옵션 (GroupBuyOption) 연결
+    request.options().forEach(optionRequest -> {
+      Member member = memberService.getMemberById(optionRequest.memberId());
+      GroupBuyOption option = GroupBuyOption.create(optionRequest.price(), member);
+      groupBuyPost.addOption(option);
+    });
+
+    // 배송 방법 (GroupBuyShipping) 연결
+    request.shippings().forEach(shippingRequest -> {
+      DeliveryMethod deliveryMethod = deliveryService.getDeliveryMethodById(
+          shippingRequest.deliveryMethodId());
+      GroupBuyShipping shipping = GroupBuyShipping.create(shippingRequest.price(), deliveryMethod);
+      groupBuyPost.addShipping(shipping);
+    });
+
+    // 4. 이미지 (ItemImage) 연결
+    List<String> imageUrls = request.imageUrls();
+    for (int i = 0; i < imageUrls.size(); i++) {
+      ItemImage image = ItemImage.create(imageUrls.get(i), i);
+      groupBuyPost.addImage(image);
+    }
+
+    // 최종 저장 (CascadeType.ALL 덕분에 한 번에 다 저장됨)
+    groupBuyRepository.save(groupBuyPost);
+
+    return GroupBuyCreateResponse.of(groupBuyPost.getId());
+  }
+
+  // 상품명 자동완성
+  public List<String> searchTitles(Long artistId, String keyword) {
+    Pageable pageable = PageRequest.of(0, 5); // 최대 5개만 조회
+    return groupBuyRepository.findTitlesByKeyword(artistId, keyword, pageable.getPageSize());
+  }
+}

--- a/src/main/java/org/sopt/poti/domain/image/controller/ImageController.java
+++ b/src/main/java/org/sopt/poti/domain/image/controller/ImageController.java
@@ -6,13 +6,16 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.image.dto.request.PresignedUrlRequest;
+import org.sopt.poti.domain.image.dto.response.ImagePresignedUrlsResponse;
 import org.sopt.poti.domain.image.dto.response.PresignedUrlResponse;
 import org.sopt.poti.global.common.ApiResponse;
 import org.sopt.poti.global.common.SuccessStatus;
 import org.sopt.poti.global.external.s3.S3Service;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,14 +28,15 @@ public class ImageController {
 
   @GetMapping("/presigned-url")
   @Operation(summary = "Presigned URL 다중 발급", description = "S3에 이미지를 업로드하기 위한 Presigned URL을 요청 수(count)만큼 발급받습니다.")
-  public ApiResponse<List<PresignedUrlResponse>> getPresignedUrl(
+  @ResponseStatus(HttpStatus.OK)
+  public ApiResponse<ImagePresignedUrlsResponse> getPresignedUrl(
       @ModelAttribute @Valid PresignedUrlRequest request
   ) {
-    List<PresignedUrlResponse> response = s3Service.getPresignedUrls(
+    List<PresignedUrlResponse> urls = s3Service.getPresignedUrls(
         request.type(),
         request.count(),
         request.extension()
     );
-    return ApiResponse.success(SuccessStatus.OK, response);
+    return ApiResponse.success(SuccessStatus.OK, ImagePresignedUrlsResponse.of(urls));
   }
 }

--- a/src/main/java/org/sopt/poti/domain/image/dto/response/ImagePresignedUrlsResponse.java
+++ b/src/main/java/org/sopt/poti/domain/image/dto/response/ImagePresignedUrlsResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.poti.domain.image.dto.response;
+
+import java.util.List;
+
+public record ImagePresignedUrlsResponse(
+    List<PresignedUrlResponse> urls
+) {
+    public static ImagePresignedUrlsResponse of(List<PresignedUrlResponse> urls) {
+        return new ImagePresignedUrlsResponse(urls);
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/poti/domain/user/service/UserService.java
@@ -1,0 +1,22 @@
+package org.sopt.poti.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.user.entity.User;
+import org.sopt.poti.domain.user.repository.UserRepository;
+import org.sopt.poti.global.error.BusinessException;
+import org.sopt.poti.global.error.ErrorStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/poti/global/config/QueryDslConfig.java
+++ b/src/main/java/org/sopt/poti/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package org.sopt.poti.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/sopt/poti/global/dev/DevController.java
+++ b/src/main/java/org/sopt/poti/global/dev/DevController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/dev")
 @RequiredArgsConstructor
-@Profile({"local", "dev", "default"})
+@Profile({"local", "dev"})
 @Tag(name = "Dev", description = "개발자 테스트용 API")
 public class DevController {
 

--- a/src/main/java/org/sopt/poti/global/dev/DevController.java
+++ b/src/main/java/org/sopt/poti/global/dev/DevController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/dev")
 @RequiredArgsConstructor
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "default"})
 @Tag(name = "Dev", description = "개발자 테스트용 API")
 public class DevController {
 

--- a/src/main/java/org/sopt/poti/global/error/ErrorStatus.java
+++ b/src/main/java/org/sopt/poti/global/error/ErrorStatus.java
@@ -37,6 +37,9 @@ public enum ErrorStatus {
   USER_NOT_FOUND(40400, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
   ITEM_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
   NOT_FOUND_HANDLER(40402, HttpStatus.NOT_FOUND, "존재하지 않는 API 경로입니다."),
+  ARTIST_NOT_FOUND(40403, HttpStatus.NOT_FOUND, "존재하지 않는 아티스트입니다."),
+  MEMBER_NOT_FOUND(40404, HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다."),
+  DELIVERY_METHOD_NOT_FOUND(40405, HttpStatus.NOT_FOUND, "존재하지 않는 배송 방법입니다."),
 
   /**
    * 500 Internal Server Error


### PR DESCRIPTION
##  📌 관련 이슈
  <!-- 관련 이슈를 적어주세요. -->
   - close #25 
   - close #27 

##  ✨ 변경 사항
  <!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

  1. 공동구매(GroupBuy) 도메인 API 구현
   - 게시글 등록 (`POST /api/v1/groupbuys`):
       - GroupBuyCreateRequest DTO를 통해 게시글 정보, 옵션, 배송 방법, 이미지 키 리스트를 받아 한 번에 저장합니다.
       - GroupBuyPost 엔티티와 연관된 GroupBuyOption, GroupBuyShipping, ItemImage 엔티티를 CascadeType.ALL을 활용하여 일괄 처리합니다.
   - 상품명 자동완성 (`GET /api/v1/groupbuys/titles`):
       - QueryDSL을 도입하여 artistId와 keyword를 조건으로 하는 동적 검색 쿼리(searchTitles)를 구현했습니다.
       - DISTINCT와 LIMIT를 적용하여 중복 없는 상품명 5개를 반환합니다.

  2. 아키텍처 및 컨벤션 개선
   - Service 레이어 분리: GroupBuyService에서 타 도메인 Repository(UserRepository 등)를 직접 주입받는 대신, UserService, ArtistService 등 도메인별 Service를 생성하여 주입받도록 구조를 개선했습니다.
   - Response Wrapper 적용: 리스트 반환 시 ImagePresignedUrlsResponse, GroupBuyTitlesResponse 등 Wrapper DTO로 감싸서 반환하도록 컨벤션을 통일했습니다.
   - ResponseEntity 적용: 모든 컨트롤러의 반환 타입을 ResponseEntity<ApiResponse<T>>로 변경하여 일관성을 확보했습니다.

  3. 엔티티 리팩토링
   - `GroupBuyPost`: DeliveryInfo 대신 GroupBuyShipping 엔티티와 연관 관계를 맺도록 구조를 변경했습니다 (배송비 유연성 확보).
   - `ItemImage`: 이미지 순서 보장을 위해 sortOrder 필드를 추가하고, 등록 시 리스트 인덱스를 저장하도록 구현했습니다.

##  📸 테스트 증명 (필수)
- 분철글 등록 
<img width="1380" height="1422" alt="image" src="https://github.com/user-attachments/assets/16403f24-d080-478c-ba70-e4c3e0729f64" />

- 검색
<img width="1880" height="1466" alt="image" src="https://github.com/user-attachments/assets/6db6cdfb-84fb-40bb-8708-febadbd002ec" />


##  📚 리뷰어 참고 사항
  <!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
   - QueryDSL 설정: QueryDslConfig를 추가하여 JPAQueryFactory 빈을 등록했습니다.
   - 배송 정보 구조: 배송 방법(DeliveryMethod)은 마스터 데이터로 관리하고, 공구별 배송비(price)는 GroupBuyShipping 엔티티에 저장하여 유연하게 관리합니다.

##  ✅ 체크리스트
   - [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
   - [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
   - [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
   - [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 그룹바이 게시물 생성 기능 추가 — 아티스트별 공동구매 게시물을 작성·등록할 수 있습니다.
  * 그룹바이 제목 제안 기능 추가 — 아티스트와 키워드 기반으로 관련 제목을 최대 5개까지 제안합니다.
* **개선**
  * 이미지 업로드 응답 형식 개선 — 프리사인드 URL 응답이 더 구조화된 형식으로 반환됩니다.
* **오류/메시지**
  * 멤버 및 배송 방법 관련 명확한 오류 상태 추가 — 존재하지 않는 멤버/배송 방법에 대한 안내가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->