### PR TITLE
[FEAT] 홈 화면 데이터 구현

### DIFF
--- a/src/main/java/org/sopt/poti/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/poti/domain/auth/controller/AuthController.java
@@ -9,11 +9,10 @@ import org.sopt.poti.domain.auth.dto.response.AuthResponse;
 import org.sopt.poti.domain.auth.service.AuthService;
 import org.sopt.poti.global.common.ApiResponse;
 import org.sopt.poti.global.common.SuccessStatus;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,13 +21,15 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Auth", description = "인증 관련 API")
 public class AuthController {
 
-    private final AuthService authService;
+  private final AuthService authService;
 
-    @PostMapping("/login")
-    @ResponseStatus(HttpStatus.OK) // 200 OK
-    @Operation(summary = "소셜 로그인/회원가입", description = "카카오 소셜 로그인을 수행하고 액세스/리프레시 토큰을 발급합니다.")
-    public ApiResponse<AuthResponse> socialLogin(@RequestBody @Valid AuthRequest request) {
-        AuthResponse response = authService.socialLogin(request);
-        return ApiResponse.success(SuccessStatus.OK, response);
-    }
+  @PostMapping("/login")
+  @Operation(summary = "소셜 로그인/회원가입", description = "카카오 소셜 로그인을 수행하고 액세스/리프레시 토큰을 발급합니다.")
+  public ResponseEntity<ApiResponse<AuthResponse>> socialLogin(
+      @RequestBody @Valid AuthRequest request) {
+    AuthResponse response = authService.socialLogin(request);
+    return ResponseEntity.ok(
+        ApiResponse.success(SuccessStatus.OK, response)
+    );
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/org/sopt/poti/domain/auth/entity/RefreshToken.java
@@ -13,16 +13,16 @@ import org.springframework.data.redis.core.TimeToLive;
 @Builder
 public class RefreshToken {
 
-    @Id
-    private Long userId; // Redis Key: refreshToken:{userId}
+  @Id
+  private Long userId; // Redis Key => refreshToken:{userId}
 
-    private String refreshToken;
+  private String refreshToken;
 
-    @TimeToLive
-    private Long ttl; // 만료 시간 (초 단위)
+  @TimeToLive
+  private Long ttl; // 만료 시간 (초 단위)
 
-    public void updateRefreshToken(String refreshToken, Long ttl) {
-        this.refreshToken = refreshToken;
-        this.ttl = ttl;
-    }
+  public void updateRefreshToken(String refreshToken, Long ttl) {
+    this.refreshToken = refreshToken;
+    this.ttl = ttl;
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
@@ -28,7 +28,7 @@ public class AuthService {
 
   private final UserRepository userRepository;
   private final JwtTokenProvider jwtTokenProvider;
-  private final KakaoFeignClient kakaoFeignClient; // FeignClient 주입
+  private final KakaoFeignClient kakaoFeignClient;
   private final RefreshTokenRepository refreshTokenRepository;
 
   @Value("${jwt.refresh-token-validity}")
@@ -53,6 +53,7 @@ public class AuthService {
       user = existingUser.get();
       // 기존 유저이지만, 닉네임이 없으면 온보딩이 필요함
       isNewUser = (user.getNickname() == null);
+      // TODO: 기존 유저의 정보(닉네임, 프로필 이미지 등)가 변경되었다면 업데이트 로직 추가
     } else {
       KakaoUserResponse.KakaoAccount kakaoAccount = kakaoUserResponse.getKakaoAccount();
       String email = null;
@@ -75,7 +76,7 @@ public class AuthService {
           email,
           nickname,
           profileImageUrl,
-          null // favoriteArtist는 신규 가입 시점에 null
+          null
       );
       userRepository.save(user);
       isNewUser = true;
@@ -90,7 +91,7 @@ public class AuthService {
     refreshTokenRepository.save(RefreshToken.builder()
         .userId(user.getId())
         .refreshToken(refreshToken)
-        .ttl(refreshTokenValidity / 1000) // ms -> s 변환
+        .ttl(refreshTokenValidity / 1000)
         .build());
 
     return AuthResponse.builder()

--- a/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
@@ -3,6 +3,7 @@ package org.sopt.poti.domain.groupbuy.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyCreateRequest;
@@ -13,17 +14,18 @@ import org.sopt.poti.global.common.ApiResponse;
 import org.sopt.poti.global.common.SuccessStatus;
 import org.sopt.poti.global.security.UserPrincipal;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/posts")
+@RequestMapping("/api/v1/groupbuys")
 @RequiredArgsConstructor
 @Tag(name = "GroupBuy", description = "공동구매 관련 API")
 public class GroupBuyController {
@@ -31,25 +33,31 @@ public class GroupBuyController {
   private final GroupBuyService groupBuyService;
 
   @PostMapping
-  @ResponseStatus(HttpStatus.CREATED)
   @Operation(summary = "공동구매 게시글 등록", description = "새로운 공동구매 게시글을 등록합니다.")
-  public ApiResponse<GroupBuyCreateResponse> createGroupBuy(
+  public ResponseEntity<ApiResponse<GroupBuyCreateResponse>> createGroupBuy(
       @AuthenticationPrincipal UserPrincipal userPrincipal,
       @RequestBody @Valid GroupBuyCreateRequest request
   ) {
     GroupBuyCreateResponse response = groupBuyService.createGroupBuyPost(userPrincipal.getUserId(),
         request);
-    return ApiResponse.success(SuccessStatus.CREATED, response);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.success(SuccessStatus.CREATED, response));
   }
 
   @GetMapping("/titles")
-  @ResponseStatus(HttpStatus.OK)
   @Operation(summary = "상품명 자동완성/추천", description = "입력 키워드를 기반으로 공동구매 상품명 리스트를 추천합니다.")
-  public ApiResponse<GroupBuyTitlesResponse> searchTitles(
+  public ResponseEntity<ApiResponse<GroupBuyTitlesResponse>> searchTitles(
       @RequestParam Long artistId,
       @RequestParam String keyword
   ) {
+    if (!StringUtils.hasText(keyword)) {
+      // 키워드가 없거나 공백이면 빈 리스트 반환
+      return ResponseEntity.status(HttpStatus.OK)
+          .body(ApiResponse.success(SuccessStatus.OK,
+              GroupBuyTitlesResponse.of(Collections.emptyList())));
+    }
     List<String> titles = groupBuyService.searchTitles(artistId, keyword);
-    return ApiResponse.success(SuccessStatus.OK, GroupBuyTitlesResponse.of(titles));
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(ApiResponse.success(SuccessStatus.OK, GroupBuyTitlesResponse.of(titles)));
   }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
@@ -24,9 +24,13 @@ import org.sopt.poti.domain.artist.entity.Artist;
 import org.sopt.poti.domain.user.entity.User;
 import org.sopt.poti.global.entity.BaseTimeEntity;
 
+import jakarta.persistence.Index; // Import Index
+
 @Getter
 @Entity
-@Table(name = "group_buy_posts")
+@Table(name = "group_buy_posts", indexes = { // 인덱스 추가
+    @Index(name = "idx_group_buy_post_title", columnList = "title")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupBuyPost extends BaseTimeEntity {
 

--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
@@ -9,6 +9,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -23,8 +24,6 @@ import lombok.NoArgsConstructor;
 import org.sopt.poti.domain.artist.entity.Artist;
 import org.sopt.poti.domain.user.entity.User;
 import org.sopt.poti.global.entity.BaseTimeEntity;
-
-import jakarta.persistence.Index; // Import Index
 
 @Getter
 @Entity

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
@@ -1,11 +1,15 @@
 package org.sopt.poti.domain.groupbuy.repository;
 
 import java.util.List;
-import org.sopt.poti.domain.home.dto.response.HomeGroupBuyItem; // Import HomeGroupBuyItem
+import org.sopt.poti.domain.home.dto.response.HomeGroupBuyItem;
 
 public interface GroupBuyRepositoryCustom {
-    List<String> findTitlesByKeyword(Long artistId, String keyword, int limit);
 
-    List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId, int limit); // userId도 필요 (nickname 등)
-    List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId, int limit); // userId도 필요
+  List<String> findTitlesByKeyword(Long artistId, String keyword, int limit);
+
+  List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId,
+      int limit); // userId도 필요 (nickname 등)
+
+  List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId,
+      int limit); // userId도 필요
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
@@ -1,7 +1,11 @@
 package org.sopt.poti.domain.groupbuy.repository;
 
 import java.util.List;
+import org.sopt.poti.domain.home.dto.response.HomeGroupBuyItem; // Import HomeGroupBuyItem
 
 public interface GroupBuyRepositoryCustom {
     List<String> findTitlesByKeyword(Long artistId, String keyword, int limit);
+
+    List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId, int limit); // userId도 필요 (nickname 등)
+    List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId, int limit); // userId도 필요
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
@@ -5,11 +5,12 @@ import org.sopt.poti.domain.home.dto.response.HomeGroupBuyItem;
 
 public interface GroupBuyRepositoryCustom {
 
-  List<String> findTitlesByKeyword(Long artistId, String keyword, int limit);
+    List<String> findTitlesByKeyword(Long artistId, String keyword, int limit);
 
-  List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId,
-      int limit); // userId도 필요 (nickname 등)
 
-  List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId,
-      int limit); // userId도 필요
+
+    List<HomeGroupBuyItem> findPopularTitlesByArtist(Long artistId, int limit);
+
+    List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long artistId, int limit);
+
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
@@ -5,12 +5,10 @@ import org.sopt.poti.domain.home.dto.response.HomeGroupBuyItem;
 
 public interface GroupBuyRepositoryCustom {
 
-    List<String> findTitlesByKeyword(Long artistId, String keyword, int limit);
+  List<String> findTitlesByKeyword(Long artistId, String keyword, int limit);
 
+  List<HomeGroupBuyItem> findPopularTitlesByArtist(Long artistId, int limit);
 
-
-    List<HomeGroupBuyItem> findPopularTitlesByArtist(Long artistId, int limit);
-
-    List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long artistId, int limit);
+  List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long artistId, int limit);
 
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
@@ -4,6 +4,7 @@ import static org.sopt.poti.domain.artist.entity.QArtist.artist;
 import static org.sopt.poti.domain.groupbuy.entity.QGroupBuyPost.groupBuyPost;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -19,8 +20,6 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
 
   @Override
   public List<String> findTitlesByKeyword(Long artistId, String keyword, int limit) {
-    QGroupBuyPost groupBuyPost = QGroupBuyPost.groupBuyPost;
-
     return queryFactory
         .selectDistinct(groupBuyPost.title)
         .from(groupBuyPost)
@@ -32,81 +31,76 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
         .fetch();
   }
 
-import com.querydsl.core.types.dsl.BooleanExpression; // Import 추가
+  @Override
+  public List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId, int limit) {
+    QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+    QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
+    QItemImage subItemImage = new QItemImage("subItemImage");
 
-// ... (기존 imports)
-
-    @Override
-    public List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId, int limit) {
-        QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
-        QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
-        QItemImage subItemImage = new QItemImage("subItemImage");
-
-        return queryFactory
-                .select(Projections.constructor(HomeGroupBuyItem.class,
-                        groupBuyPost.title,
-                        artist.name,
-                        JPAExpressions.select(subItemImage.imageUrl)
-                                .from(subItemImage)
-                                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
-                                .where(subGroupBuyPostForImage.id.eq(
-                                        JPAExpressions.select(subGroupBuyPost.id.max())
-                                                .from(subGroupBuyPost)
-                                                .where(subGroupBuyPost.title.eq(groupBuyPost.title)
-                                                        .and(subGroupBuyPost.artist.id.eq(artistId))
-                                                        .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id))) // 아티스트 일치 조건 추가 (명시적)
-                                ))
-                                .limit(1),
-                        groupBuyPost.id.count(),
-                        groupBuyPost.id.count().when(0L).then("")
-                                .otherwise("인기").as("tag")
+    return queryFactory
+        .select(Projections.constructor(HomeGroupBuyItem.class,
+            groupBuyPost.title,
+            artist.name,
+            JPAExpressions.select(subItemImage.imageUrl)
+                .from(subItemImage)
+                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
+                .where(subGroupBuyPostForImage.id.eq(
+                    JPAExpressions.select(subGroupBuyPost.id.max())
+                        .from(subGroupBuyPost)
+                        .where(subGroupBuyPost.title.eq(groupBuyPost.title)
+                            .and(subGroupBuyPost.artist.id.eq(artistId))
+                            .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
                 ))
-                .from(groupBuyPost)
-                .join(groupBuyPost.artist, artist)
-                .where(groupBuyPost.artist.id.eq(artistId))
-                .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id) // artist.id 그룹핑 추가
-                .orderBy(groupBuyPost.id.count().desc())
-                .limit(limit)
-                .fetch();
-    }
+                .limit(1),
+            groupBuyPost.id.count(),
+            groupBuyPost.id.count().when(0L).then("")
+                .otherwise("인기").as("tag")
+        ))
+        .from(groupBuyPost)
+        .join(groupBuyPost.artist, artist)
+        .where(groupBuyPost.artist.id.eq(artistId))
+        .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
+        .orderBy(groupBuyPost.id.count().desc())
+        .limit(limit)
+        .fetch();
+  }
 
-    @Override
-    public List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId, int limit) {
-        QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
-        QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
-        QItemImage subItemImage = new QItemImage("subItemImage");
+  @Override
+  public List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId,
+      int limit) {
+    QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+    QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
+    QItemImage subItemImage = new QItemImage("subItemImage");
 
-        return queryFactory
-                .select(Projections.constructor(HomeGroupBuyItem.class,
-                        groupBuyPost.title,
-                        artist.name,
-                        JPAExpressions.select(subItemImage.imageUrl)
-                                .from(subItemImage)
-                                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
-                                .where(subGroupBuyPostForImage.id.eq(
-                                        JPAExpressions.select(subGroupBuyPost.id.max())
-                                                .from(subGroupBuyPost)
-                                                .where(subGroupBuyPost.title.eq(groupBuyPost.title)
-                                                        .and(artistIdNe(artistId, subGroupBuyPost)) // 서브쿼리에도 제외 조건 적용? 아니면 같은 아티스트?
-                                                        // 서브쿼리는 "해당 그룹(Title, Artist)"의 최신 글을 찾는 것이므로
-                                                        // groupBuyPost.artist.id와 일치해야 함.
-                                                        .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id))) 
-                                ))
-                                .limit(1),
-                        groupBuyPost.id.count(),
-                        groupBuyPost.id.count().when(0L).then("")
-                                .otherwise("인기").as("tag")
+    return queryFactory
+        .select(Projections.constructor(HomeGroupBuyItem.class,
+            groupBuyPost.title,
+            artist.name,
+            JPAExpressions.select(subItemImage.imageUrl)
+                .from(subItemImage)
+                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
+                .where(subGroupBuyPostForImage.id.eq(
+                    JPAExpressions.select(subGroupBuyPost.id.max())
+                        .from(subGroupBuyPost)
+                        .where(subGroupBuyPost.title.eq(groupBuyPost.title)
+                            .and(artistIdNe(artistId, subGroupBuyPost))
+                            .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
                 ))
-                .from(groupBuyPost)
-                .join(groupBuyPost.artist, artist)
-                .where(artistIdNe(artistId, groupBuyPost)) // 동적 쿼리 적용
-                .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
-                .orderBy(groupBuyPost.id.count().desc())
-                .limit(limit)
-                .fetch();
-    }
+                .limit(1),
+            groupBuyPost.id.count(),
+            groupBuyPost.id.count().when(0L).then("")
+                .otherwise("인기").as("tag")
+        ))
+        .from(groupBuyPost)
+        .join(groupBuyPost.artist, artist)
+        .where(artistIdNe(artistId, groupBuyPost))
+        .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
+        .orderBy(groupBuyPost.id.count().desc())
+        .limit(limit)
+        .fetch();
+  }
 
-    private BooleanExpression artistIdNe(Long artistId, QGroupBuyPost post) {
-        return artistId != null ? post.artist.id.ne(artistId) : null;
-    }
+  private BooleanExpression artistIdNe(Long artistId, QGroupBuyPost post) {
+    return artistId != null ? post.artist.id.ne(artistId) : null;
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
@@ -32,72 +32,81 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
         .fetch();
   }
 
-  @Override
-  public List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId, int limit) {
-    QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
-    QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
-    QItemImage subItemImage = new QItemImage("subItemImage");
+import com.querydsl.core.types.dsl.BooleanExpression; // Import 추가
 
-    return queryFactory
-        .select(Projections.constructor(HomeGroupBuyItem.class,
-            groupBuyPost.title,
-            artist.name,
-            JPAExpressions.select(
-                    subItemImage.imageUrl)
-                .from(subItemImage)
-                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
-                .where(subGroupBuyPostForImage.id.eq(
-                    JPAExpressions.select(subGroupBuyPost.id.max())
-                        .from(subGroupBuyPost)
-                        .where(subGroupBuyPost.title.eq(groupBuyPost.title)
-                            .and(subGroupBuyPost.artist.id.eq(artistId)))
+// ... (기존 imports)
+
+    @Override
+    public List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId, int limit) {
+        QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+        QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
+        QItemImage subItemImage = new QItemImage("subItemImage");
+
+        return queryFactory
+                .select(Projections.constructor(HomeGroupBuyItem.class,
+                        groupBuyPost.title,
+                        artist.name,
+                        JPAExpressions.select(subItemImage.imageUrl)
+                                .from(subItemImage)
+                                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
+                                .where(subGroupBuyPostForImage.id.eq(
+                                        JPAExpressions.select(subGroupBuyPost.id.max())
+                                                .from(subGroupBuyPost)
+                                                .where(subGroupBuyPost.title.eq(groupBuyPost.title)
+                                                        .and(subGroupBuyPost.artist.id.eq(artistId))
+                                                        .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id))) // 아티스트 일치 조건 추가 (명시적)
+                                ))
+                                .limit(1),
+                        groupBuyPost.id.count(),
+                        groupBuyPost.id.count().when(0L).then("")
+                                .otherwise("인기").as("tag")
                 ))
-                .limit(1),
-            groupBuyPost.id.count(),
-            groupBuyPost.id.count().when(0L)
-                .then("")
-                .otherwise("인기").as("tag")
-        ))
-        .from(groupBuyPost)
-        .join(groupBuyPost.artist, artist)
-        .where(groupBuyPost.artist.id.eq(artistId))
-        .groupBy(groupBuyPost.title, artist.name)
-        .orderBy(groupBuyPost.id.count().desc())
-        .limit(limit)
-        .fetch();
-  }
+                .from(groupBuyPost)
+                .join(groupBuyPost.artist, artist)
+                .where(groupBuyPost.artist.id.eq(artistId))
+                .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id) // artist.id 그룹핑 추가
+                .orderBy(groupBuyPost.id.count().desc())
+                .limit(limit)
+                .fetch();
+    }
 
-  @Override
-  public List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId,
-      int limit) {
-    QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
-    QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
-    QItemImage subItemImage = new QItemImage("subItemImage");
+    @Override
+    public List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId, int limit) {
+        QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+        QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
+        QItemImage subItemImage = new QItemImage("subItemImage");
 
-    return queryFactory
-        .select(Projections.constructor(HomeGroupBuyItem.class,
-            groupBuyPost.title,
-            artist.name,
-            JPAExpressions.select(subItemImage.imageUrl)
-                .from(subItemImage)
-                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
-                .where(subGroupBuyPostForImage.id.eq(
-                    JPAExpressions.select(subGroupBuyPost.id.max())
-                        .from(subGroupBuyPost)
-                        .where(subGroupBuyPost.title.eq(groupBuyPost.title)
-                            .and(subGroupBuyPost.artist.id.ne(artistId)))
+        return queryFactory
+                .select(Projections.constructor(HomeGroupBuyItem.class,
+                        groupBuyPost.title,
+                        artist.name,
+                        JPAExpressions.select(subItemImage.imageUrl)
+                                .from(subItemImage)
+                                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
+                                .where(subGroupBuyPostForImage.id.eq(
+                                        JPAExpressions.select(subGroupBuyPost.id.max())
+                                                .from(subGroupBuyPost)
+                                                .where(subGroupBuyPost.title.eq(groupBuyPost.title)
+                                                        .and(artistIdNe(artistId, subGroupBuyPost)) // 서브쿼리에도 제외 조건 적용? 아니면 같은 아티스트?
+                                                        // 서브쿼리는 "해당 그룹(Title, Artist)"의 최신 글을 찾는 것이므로
+                                                        // groupBuyPost.artist.id와 일치해야 함.
+                                                        .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id))) 
+                                ))
+                                .limit(1),
+                        groupBuyPost.id.count(),
+                        groupBuyPost.id.count().when(0L).then("")
+                                .otherwise("인기").as("tag")
                 ))
-                .limit(1),
-            groupBuyPost.id.count(),
-            groupBuyPost.id.count().when(0L).then("")
-                .otherwise("인기").as("tag")
-        ))
-        .from(groupBuyPost)
-        .join(groupBuyPost.artist, artist)
-        .where(groupBuyPost.artist.id.ne(artistId))
-        .groupBy(groupBuyPost.title, artist.name)
-        .orderBy(groupBuyPost.id.count().desc())
-        .limit(limit)
-        .fetch();
-  }
+                .from(groupBuyPost)
+                .join(groupBuyPost.artist, artist)
+                .where(artistIdNe(artistId, groupBuyPost)) // 동적 쿼리 적용
+                .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
+                .orderBy(groupBuyPost.id.count().desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    private BooleanExpression artistIdNe(Long artistId, QGroupBuyPost post) {
+        return artistId != null ? post.artist.id.ne(artistId) : null;
+    }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
@@ -32,7 +32,7 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
   }
 
   @Override
-  public List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId, int limit) {
+  public List<HomeGroupBuyItem> findPopularTitlesByArtist(Long artistId, int limit) {
     QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
     QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
     QItemImage subItemImage = new QItemImage("subItemImage");
@@ -51,8 +51,8 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
                             .and(subGroupBuyPost.artist.id.eq(artistId))
                             .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
                 ))
-                .limit(1),
-            groupBuyPost.id.count(),
+                .orderBy(subItemImage.sortOrder.asc()) // sortOrder 정렬 추가
+                .limit(1), groupBuyPost.id.count(),
             groupBuyPost.id.count().when(0L).then("")
                 .otherwise("인기").as("tag")
         ))
@@ -66,8 +66,7 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
   }
 
   @Override
-  public List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId,
-      int limit) {
+  public List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long artistId, int limit) {
     QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
     QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
     QItemImage subItemImage = new QItemImage("subItemImage");
@@ -86,6 +85,7 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
                             .and(artistIdNe(artistId, subGroupBuyPost))
                             .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
                 ))
+                .orderBy(subItemImage.sortOrder.asc())
                 .limit(1),
             groupBuyPost.id.count(),
             groupBuyPost.id.count().when(0L).then("")

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
@@ -1,9 +1,18 @@
 package org.sopt.poti.domain.groupbuy.repository;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.groupbuy.entity.QGroupBuyPost;
+import org.sopt.poti.domain.groupbuy.entity.QItemImage;
+import org.sopt.poti.domain.artist.entity.QArtist;
+import org.sopt.poti.domain.home.dto.response.HomeGroupBuyItem;
+
+import static org.sopt.poti.domain.groupbuy.entity.QGroupBuyPost.groupBuyPost;
+import static org.sopt.poti.domain.groupbuy.entity.QItemImage.itemImage;
+import static org.sopt.poti.domain.artist.entity.QArtist.artist;
 
 @RequiredArgsConstructor
 public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
@@ -21,6 +30,73 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
                         groupBuyPost.artist.id.eq(artistId),
                         groupBuyPost.title.contains(keyword)
                 )
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId, int limit) {
+        QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost"); // Subquery alias
+        QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
+        QItemImage subItemImage = new QItemImage("subItemImage");
+
+
+        return queryFactory
+                .select(Projections.constructor(HomeGroupBuyItem.class,
+                        groupBuyPost.title,
+                        artist.name,
+                        JPAExpressions.select(subItemImage.imageUrl) // Subquery for image (latest post's image for this title)
+                                .from(subItemImage)
+                                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
+                                .where(subGroupBuyPostForImage.id.eq(
+                                        JPAExpressions.select(subGroupBuyPost.id.max()) // Get latest post ID for title
+                                                .from(subGroupBuyPost)
+                                                .where(subGroupBuyPost.title.eq(groupBuyPost.title)
+                                                        .and(subGroupBuyPost.artist.id.eq(artistId)))
+                                ))
+                                .limit(1), // Get only one image URL
+                        groupBuyPost.id.count(), // postCount (count of posts with this title)
+                        groupBuyPost.id.count().when(0L).then("") // Default tag, '인기' tag logic to be implemented later
+                                .otherwise("인기").as("tag") // QueryDSL will handle type conversion if HomeGroupBuyItem constructor expects String
+                ))
+                .from(groupBuyPost)
+                .join(groupBuyPost.artist, artist)
+                .where(groupBuyPost.artist.id.eq(artistId))
+                .groupBy(groupBuyPost.title, artist.name) // Group by title and artist name
+                .orderBy(groupBuyPost.id.count().desc()) // Order by postCount (popular)
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId, int limit) {
+        QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost"); // Subquery alias
+        QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
+        QItemImage subItemImage = new QItemImage("subItemImage");
+
+        return queryFactory
+                .select(Projections.constructor(HomeGroupBuyItem.class,
+                        groupBuyPost.title,
+                        artist.name,
+                        JPAExpressions.select(subItemImage.imageUrl)
+                                .from(subItemImage)
+                                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
+                                .where(subGroupBuyPostForImage.id.eq(
+                                        JPAExpressions.select(subGroupBuyPost.id.max())
+                                                .from(subGroupBuyPost)
+                                                .where(subGroupBuyPost.title.eq(groupBuyPost.title)
+                                                        .and(subGroupBuyPost.artist.id.ne(artistId))) // Exclude artist
+                                ))
+                                .limit(1),
+                        groupBuyPost.id.count(),
+                        groupBuyPost.id.count().when(0L).then("")
+                                .otherwise("인기").as("tag")
+                ))
+                .from(groupBuyPost)
+                .join(groupBuyPost.artist, artist)
+                .where(groupBuyPost.artist.id.ne(artistId)) // Exclude artist
+                .groupBy(groupBuyPost.title, artist.name)
+                .orderBy(groupBuyPost.id.count().desc())
                 .limit(limit)
                 .fetch();
     }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
@@ -1,5 +1,8 @@
 package org.sopt.poti.domain.groupbuy.repository;
 
+import static org.sopt.poti.domain.artist.entity.QArtist.artist;
+import static org.sopt.poti.domain.groupbuy.entity.QGroupBuyPost.groupBuyPost;
+
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -7,97 +10,94 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.groupbuy.entity.QGroupBuyPost;
 import org.sopt.poti.domain.groupbuy.entity.QItemImage;
-import org.sopt.poti.domain.artist.entity.QArtist;
 import org.sopt.poti.domain.home.dto.response.HomeGroupBuyItem;
-
-import static org.sopt.poti.domain.groupbuy.entity.QGroupBuyPost.groupBuyPost;
-import static org.sopt.poti.domain.groupbuy.entity.QItemImage.itemImage;
-import static org.sopt.poti.domain.artist.entity.QArtist.artist;
 
 @RequiredArgsConstructor
 public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
 
-    private final JPAQueryFactory queryFactory;
+  private final JPAQueryFactory queryFactory;
 
-    @Override
-    public List<String> findTitlesByKeyword(Long artistId, String keyword, int limit) {
-        QGroupBuyPost groupBuyPost = QGroupBuyPost.groupBuyPost;
+  @Override
+  public List<String> findTitlesByKeyword(Long artistId, String keyword, int limit) {
+    QGroupBuyPost groupBuyPost = QGroupBuyPost.groupBuyPost;
 
-        return queryFactory
-                .selectDistinct(groupBuyPost.title)
-                .from(groupBuyPost)
-                .where(
-                        groupBuyPost.artist.id.eq(artistId),
-                        groupBuyPost.title.contains(keyword)
-                )
-                .limit(limit)
-                .fetch();
-    }
+    return queryFactory
+        .selectDistinct(groupBuyPost.title)
+        .from(groupBuyPost)
+        .where(
+            groupBuyPost.artist.id.eq(artistId),
+            groupBuyPost.title.contains(keyword)
+        )
+        .limit(limit)
+        .fetch();
+  }
 
-    @Override
-    public List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId, int limit) {
-        QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost"); // Subquery alias
-        QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
-        QItemImage subItemImage = new QItemImage("subItemImage");
+  @Override
+  public List<HomeGroupBuyItem> findPopularTitlesByArtist(Long userId, Long artistId, int limit) {
+    QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+    QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
+    QItemImage subItemImage = new QItemImage("subItemImage");
 
-
-        return queryFactory
-                .select(Projections.constructor(HomeGroupBuyItem.class,
-                        groupBuyPost.title,
-                        artist.name,
-                        JPAExpressions.select(subItemImage.imageUrl) // Subquery for image (latest post's image for this title)
-                                .from(subItemImage)
-                                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
-                                .where(subGroupBuyPostForImage.id.eq(
-                                        JPAExpressions.select(subGroupBuyPost.id.max()) // Get latest post ID for title
-                                                .from(subGroupBuyPost)
-                                                .where(subGroupBuyPost.title.eq(groupBuyPost.title)
-                                                        .and(subGroupBuyPost.artist.id.eq(artistId)))
-                                ))
-                                .limit(1), // Get only one image URL
-                        groupBuyPost.id.count(), // postCount (count of posts with this title)
-                        groupBuyPost.id.count().when(0L).then("") // Default tag, '인기' tag logic to be implemented later
-                                .otherwise("인기").as("tag") // QueryDSL will handle type conversion if HomeGroupBuyItem constructor expects String
+    return queryFactory
+        .select(Projections.constructor(HomeGroupBuyItem.class,
+            groupBuyPost.title,
+            artist.name,
+            JPAExpressions.select(
+                    subItemImage.imageUrl)
+                .from(subItemImage)
+                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
+                .where(subGroupBuyPostForImage.id.eq(
+                    JPAExpressions.select(subGroupBuyPost.id.max())
+                        .from(subGroupBuyPost)
+                        .where(subGroupBuyPost.title.eq(groupBuyPost.title)
+                            .and(subGroupBuyPost.artist.id.eq(artistId)))
                 ))
-                .from(groupBuyPost)
-                .join(groupBuyPost.artist, artist)
-                .where(groupBuyPost.artist.id.eq(artistId))
-                .groupBy(groupBuyPost.title, artist.name) // Group by title and artist name
-                .orderBy(groupBuyPost.id.count().desc()) // Order by postCount (popular)
-                .limit(limit)
-                .fetch();
-    }
+                .limit(1),
+            groupBuyPost.id.count(),
+            groupBuyPost.id.count().when(0L)
+                .then("")
+                .otherwise("인기").as("tag")
+        ))
+        .from(groupBuyPost)
+        .join(groupBuyPost.artist, artist)
+        .where(groupBuyPost.artist.id.eq(artistId))
+        .groupBy(groupBuyPost.title, artist.name)
+        .orderBy(groupBuyPost.id.count().desc())
+        .limit(limit)
+        .fetch();
+  }
 
-    @Override
-    public List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId, int limit) {
-        QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost"); // Subquery alias
-        QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
-        QItemImage subItemImage = new QItemImage("subItemImage");
+  @Override
+  public List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long userId, Long artistId,
+      int limit) {
+    QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+    QGroupBuyPost subGroupBuyPostForImage = new QGroupBuyPost("subGroupBuyPostForImage");
+    QItemImage subItemImage = new QItemImage("subItemImage");
 
-        return queryFactory
-                .select(Projections.constructor(HomeGroupBuyItem.class,
-                        groupBuyPost.title,
-                        artist.name,
-                        JPAExpressions.select(subItemImage.imageUrl)
-                                .from(subItemImage)
-                                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
-                                .where(subGroupBuyPostForImage.id.eq(
-                                        JPAExpressions.select(subGroupBuyPost.id.max())
-                                                .from(subGroupBuyPost)
-                                                .where(subGroupBuyPost.title.eq(groupBuyPost.title)
-                                                        .and(subGroupBuyPost.artist.id.ne(artistId))) // Exclude artist
-                                ))
-                                .limit(1),
-                        groupBuyPost.id.count(),
-                        groupBuyPost.id.count().when(0L).then("")
-                                .otherwise("인기").as("tag")
+    return queryFactory
+        .select(Projections.constructor(HomeGroupBuyItem.class,
+            groupBuyPost.title,
+            artist.name,
+            JPAExpressions.select(subItemImage.imageUrl)
+                .from(subItemImage)
+                .join(subItemImage.groupBuyPost, subGroupBuyPostForImage)
+                .where(subGroupBuyPostForImage.id.eq(
+                    JPAExpressions.select(subGroupBuyPost.id.max())
+                        .from(subGroupBuyPost)
+                        .where(subGroupBuyPost.title.eq(groupBuyPost.title)
+                            .and(subGroupBuyPost.artist.id.ne(artistId)))
                 ))
-                .from(groupBuyPost)
-                .join(groupBuyPost.artist, artist)
-                .where(groupBuyPost.artist.id.ne(artistId)) // Exclude artist
-                .groupBy(groupBuyPost.title, artist.name)
-                .orderBy(groupBuyPost.id.count().desc())
-                .limit(limit)
-                .fetch();
-    }
+                .limit(1),
+            groupBuyPost.id.count(),
+            groupBuyPost.id.count().when(0L).then("")
+                .otherwise("인기").as("tag")
+        ))
+        .from(groupBuyPost)
+        .join(groupBuyPost.artist, artist)
+        .where(groupBuyPost.artist.id.ne(artistId))
+        .groupBy(groupBuyPost.title, artist.name)
+        .orderBy(groupBuyPost.id.count().desc())
+        .limit(limit)
+        .fetch();
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -39,7 +39,6 @@ public class GroupBuyService {
 
     Artist artist = artistService.getArtistById(request.artistId());
 
-    // GroupBuyPost 엔티티 생성
     GroupBuyPost groupBuyPost = GroupBuyPost.create(
         request.title(),
         request.content(),
@@ -50,14 +49,12 @@ public class GroupBuyService {
         artist
     );
 
-    // 옵션 (GroupBuyOption) 연결
     request.options().forEach(optionRequest -> {
       Member member = memberService.getMemberById(optionRequest.memberId());
       GroupBuyOption option = GroupBuyOption.create(optionRequest.price(), member);
       groupBuyPost.addOption(option);
     });
 
-    // 배송 방법 (GroupBuyShipping) 연결
     request.shippings().forEach(shippingRequest -> {
       DeliveryMethod deliveryMethod = deliveryService.getDeliveryMethodById(
           shippingRequest.deliveryMethodId());
@@ -65,14 +62,12 @@ public class GroupBuyService {
       groupBuyPost.addShipping(shipping);
     });
 
-    // 이미지 (ItemImage) 연결
     List<String> imageUrls = request.imageUrls();
     for (int i = 0; i < imageUrls.size(); i++) {
       ItemImage image = ItemImage.create(imageUrls.get(i), i);
       groupBuyPost.addImage(image);
     }
 
-    // 최종 저장 (CascadeType.ALL 덕분에 한 번에 다 저장됨)
     groupBuyRepository.save(groupBuyPost);
 
     return GroupBuyCreateResponse.of(groupBuyPost.getId());

--- a/src/main/java/org/sopt/poti/domain/home/controller/HomeController.java
+++ b/src/main/java/org/sopt/poti/domain/home/controller/HomeController.java
@@ -1,0 +1,34 @@
+package org.sopt.poti.domain.home.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.home.dto.response.HomeResponse;
+import org.sopt.poti.domain.home.service.HomeService;
+import org.sopt.poti.global.common.ApiResponse;
+import org.sopt.poti.global.common.SuccessStatus;
+import org.sopt.poti.global.security.UserPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/home")
+@RequiredArgsConstructor
+@Tag(name = "Home", description = "홈 화면 API")
+public class HomeController {
+
+    private final HomeService homeService;
+
+    @GetMapping
+    @Operation(summary = "홈 화면 조회", description = "사용자의 닉네임, 최애 아티스트 공구, 다른 아티스트 공구, 배너 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<HomeResponse>> getHomeData(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        HomeResponse response = homeService.getHomeData(userPrincipal.getUserId());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessStatus.OK, response));
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/home/dto/response/HomeBanner.java
+++ b/src/main/java/org/sopt/poti/domain/home/dto/response/HomeBanner.java
@@ -1,0 +1,10 @@
+package org.sopt.poti.domain.home.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record HomeBanner(
+    Long postId,
+    String imageUrl
+) {
+}

--- a/src/main/java/org/sopt/poti/domain/home/dto/response/HomeGroupBuyItem.java
+++ b/src/main/java/org/sopt/poti/domain/home/dto/response/HomeGroupBuyItem.java
@@ -1,0 +1,13 @@
+package org.sopt.poti.domain.home.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record HomeGroupBuyItem(
+    String title,           // 상품명 (분철글 제목)
+    String artist,          // 아티스트 명
+    String postImage,       // 대표 이미지 (최신글 썸네일)
+    Long postCount,        // 해당 상품명의 총 게시글 수
+    String tag              // 태그 (예: "인기")
+) {
+}

--- a/src/main/java/org/sopt/poti/domain/home/dto/response/HomeResponse.java
+++ b/src/main/java/org/sopt/poti/domain/home/dto/response/HomeResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.poti.domain.home.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record HomeResponse(
+    String nickname,
+    String mainArtist, // 최애 아티스트명
+    List<HomeGroupBuyItem> myGroupItems,
+    List<HomeGroupBuyItem> otherGroupItems,
+    List<HomeBanner> banners
+) {
+}

--- a/src/main/java/org/sopt/poti/domain/home/service/HomeService.java
+++ b/src/main/java/org/sopt/poti/domain/home/service/HomeService.java
@@ -38,7 +38,7 @@ public class HomeService {
     // 최애 아티스트가 있는 경우
     if (user.getFavoriteArtist() != null) {
       Long favoriteArtistId = user.getFavoriteArtist().getId();
-      mainArtistName = artistService.getArtistById(favoriteArtistId).getName(); // 최애 아티스트 이름
+      mainArtistName = user.getFavoriteArtist().getName(); // user.getFavoriteArtist()에서 직접 이름 가져옴
 
       myGroupItems = groupBuyRepository.findPopularTitlesByArtist(userId, favoriteArtistId,
           ITEM_LIMIT);
@@ -54,7 +54,7 @@ public class HomeService {
           ITEM_LIMIT); // 전체 인기 상품으로 대체
     }
 
-    // 배너 로직 구현 필요 (현재는 더미)
+    // 배너 로직 구현 필요 (현재는 더미 추후에 기획에 물어보고 변경할 예정)
     List<HomeBanner> banners = List.of(
         HomeBanner.builder().postId(1L)
             .imageUrl("https://poti.s3.ap-northeast-2.amazonaws.com/banners/banner1.jpg").build(),

--- a/src/main/java/org/sopt/poti/domain/home/service/HomeService.java
+++ b/src/main/java/org/sopt/poti/domain/home/service/HomeService.java
@@ -40,17 +40,17 @@ public class HomeService {
       Long favoriteArtistId = user.getFavoriteArtist().getId();
       mainArtistName = user.getFavoriteArtist().getName(); // user.getFavoriteArtist()에서 직접 이름 가져옴
 
-      myGroupItems = groupBuyRepository.findPopularTitlesByArtist(userId, favoriteArtistId,
+      myGroupItems = groupBuyRepository.findPopularTitlesByArtist(favoriteArtistId,
           ITEM_LIMIT);
-      otherGroupItems = groupBuyRepository.findPopularTitlesExcludingArtist(userId,
-          favoriteArtistId, ITEM_LIMIT);
+      otherGroupItems = groupBuyRepository.findPopularTitlesExcludingArtist(favoriteArtistId,
+          ITEM_LIMIT);
     } else {
       // 최애 아티스트가 없는 경우 (랜덤 또는 전체 인기 상품)
       log.info("유저 ID {}의 최애 아티스트가 설정되지 않아 전체 인기 상품을 조회합니다.", userId);
       // 전체 인기 상품을 조회하는 로직 (현재는 ExcludingArtist로 빈 artistId를 넘기면 전체가 되도록 하거나, 별도 쿼리 필요)
       // 임시로 다른 그룹 인기 상품 조회 로직을 그대로 사용 (필터링 없음)
       myGroupItems = Collections.emptyList(); // 최애 아티스트 없으니 비워둠
-      otherGroupItems = groupBuyRepository.findPopularTitlesExcludingArtist(userId, null,
+      otherGroupItems = groupBuyRepository.findPopularTitlesExcludingArtist(null,
           ITEM_LIMIT); // 전체 인기 상품으로 대체
     }
 

--- a/src/main/java/org/sopt/poti/domain/home/service/HomeService.java
+++ b/src/main/java/org/sopt/poti/domain/home/service/HomeService.java
@@ -20,49 +20,54 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class HomeService {
 
-    private final UserService userService;
-    private final ArtistService artistService;
-    private final GroupBuyRepository groupBuyRepository; // GroupBuyRepositoryCustom을 사용하기 위함
+  private final UserService userService;
+  private final ArtistService artistService;
+  private final GroupBuyRepository groupBuyRepository; // GroupBuyRepositoryCustom을 사용하기 위함
 
-    private static final int ITEM_LIMIT = 5; // 홈 화면에 보여줄 아이템 개수
+  private static final int ITEM_LIMIT = 5; // 홈 화면에 보여줄 아이템 개수
 
-    public HomeResponse getHomeData(Long userId) {
-        User user = userService.getUserById(userId);
+  public HomeResponse getHomeData(Long userId) {
+    User user = userService.getUserById(userId);
 
-        String nickname = user.getNickname();
-        String mainArtistName = null;
+    String nickname = user.getNickname();
+    String mainArtistName = null;
 
-        List<HomeGroupBuyItem> myGroupItems;
-        List<HomeGroupBuyItem> otherGroupItems;
+    List<HomeGroupBuyItem> myGroupItems;
+    List<HomeGroupBuyItem> otherGroupItems;
 
-        // 최애 아티스트가 있는 경우
-        if (user.getFavoriteArtist() != null) {
-            Long favoriteArtistId = user.getFavoriteArtist().getId();
-            mainArtistName = artistService.getArtistById(favoriteArtistId).getName(); // 최애 아티스트 이름
+    // 최애 아티스트가 있는 경우
+    if (user.getFavoriteArtist() != null) {
+      Long favoriteArtistId = user.getFavoriteArtist().getId();
+      mainArtistName = artistService.getArtistById(favoriteArtistId).getName(); // 최애 아티스트 이름
 
-            myGroupItems = groupBuyRepository.findPopularTitlesByArtist(userId, favoriteArtistId, ITEM_LIMIT);
-            otherGroupItems = groupBuyRepository.findPopularTitlesExcludingArtist(userId, favoriteArtistId, ITEM_LIMIT);
-        } else {
-            // 최애 아티스트가 없는 경우 (랜덤 또는 전체 인기 상품)
-            log.info("유저 ID {}의 최애 아티스트가 설정되지 않아 전체 인기 상품을 조회합니다.", userId);
-            // 전체 인기 상품을 조회하는 로직 (현재는 ExcludingArtist로 빈 artistId를 넘기면 전체가 되도록 하거나, 별도 쿼리 필요)
-            // 임시로 다른 그룹 인기 상품 조회 로직을 그대로 사용 (필터링 없음)
-            myGroupItems = Collections.emptyList(); // 최애 아티스트 없으니 비워둠
-            otherGroupItems = groupBuyRepository.findPopularTitlesExcludingArtist(userId, null, ITEM_LIMIT); // 전체 인기 상품으로 대체
-        }
-
-        // TODO: 배너 로직 구현 필요 (현재는 더미)
-        List<HomeBanner> banners = List.of(
-            HomeBanner.builder().postId(1L).imageUrl("https://poti.s3.ap-northeast-2.amazonaws.com/banners/banner1.jpg").build(),
-            HomeBanner.builder().postId(2L).imageUrl("https://poti.s3.ap-northeast-2.amazonaws.com/banners/banner2.jpg").build()
-        );
-
-        return HomeResponse.builder()
-                .nickname(nickname)
-                .mainArtist(mainArtistName)
-                .myGroupItems(myGroupItems)
-                .otherGroupItems(otherGroupItems)
-                .banners(banners)
-                .build();
+      myGroupItems = groupBuyRepository.findPopularTitlesByArtist(userId, favoriteArtistId,
+          ITEM_LIMIT);
+      otherGroupItems = groupBuyRepository.findPopularTitlesExcludingArtist(userId,
+          favoriteArtistId, ITEM_LIMIT);
+    } else {
+      // 최애 아티스트가 없는 경우 (랜덤 또는 전체 인기 상품)
+      log.info("유저 ID {}의 최애 아티스트가 설정되지 않아 전체 인기 상품을 조회합니다.", userId);
+      // 전체 인기 상품을 조회하는 로직 (현재는 ExcludingArtist로 빈 artistId를 넘기면 전체가 되도록 하거나, 별도 쿼리 필요)
+      // 임시로 다른 그룹 인기 상품 조회 로직을 그대로 사용 (필터링 없음)
+      myGroupItems = Collections.emptyList(); // 최애 아티스트 없으니 비워둠
+      otherGroupItems = groupBuyRepository.findPopularTitlesExcludingArtist(userId, null,
+          ITEM_LIMIT); // 전체 인기 상품으로 대체
     }
+
+    // 배너 로직 구현 필요 (현재는 더미)
+    List<HomeBanner> banners = List.of(
+        HomeBanner.builder().postId(1L)
+            .imageUrl("https://poti.s3.ap-northeast-2.amazonaws.com/banners/banner1.jpg").build(),
+        HomeBanner.builder().postId(2L)
+            .imageUrl("https://poti.s3.ap-northeast-2.amazonaws.com/banners/banner2.jpg").build()
+    );
+
+    return HomeResponse.builder()
+        .nickname(nickname)
+        .mainArtist(mainArtistName)
+        .myGroupItems(myGroupItems)
+        .otherGroupItems(otherGroupItems)
+        .banners(banners)
+        .build();
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/home/service/HomeService.java
+++ b/src/main/java/org/sopt/poti/domain/home/service/HomeService.java
@@ -1,0 +1,68 @@
+package org.sopt.poti.domain.home.service;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.poti.domain.artist.service.ArtistService;
+import org.sopt.poti.domain.groupbuy.repository.GroupBuyRepository;
+import org.sopt.poti.domain.home.dto.response.HomeBanner;
+import org.sopt.poti.domain.home.dto.response.HomeGroupBuyItem;
+import org.sopt.poti.domain.home.dto.response.HomeResponse;
+import org.sopt.poti.domain.user.entity.User;
+import org.sopt.poti.domain.user.service.UserService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class HomeService {
+
+    private final UserService userService;
+    private final ArtistService artistService;
+    private final GroupBuyRepository groupBuyRepository; // GroupBuyRepositoryCustom을 사용하기 위함
+
+    private static final int ITEM_LIMIT = 5; // 홈 화면에 보여줄 아이템 개수
+
+    public HomeResponse getHomeData(Long userId) {
+        User user = userService.getUserById(userId);
+
+        String nickname = user.getNickname();
+        String mainArtistName = null;
+
+        List<HomeGroupBuyItem> myGroupItems;
+        List<HomeGroupBuyItem> otherGroupItems;
+
+        // 최애 아티스트가 있는 경우
+        if (user.getFavoriteArtist() != null) {
+            Long favoriteArtistId = user.getFavoriteArtist().getId();
+            mainArtistName = artistService.getArtistById(favoriteArtistId).getName(); // 최애 아티스트 이름
+
+            myGroupItems = groupBuyRepository.findPopularTitlesByArtist(userId, favoriteArtistId, ITEM_LIMIT);
+            otherGroupItems = groupBuyRepository.findPopularTitlesExcludingArtist(userId, favoriteArtistId, ITEM_LIMIT);
+        } else {
+            // 최애 아티스트가 없는 경우 (랜덤 또는 전체 인기 상품)
+            log.info("유저 ID {}의 최애 아티스트가 설정되지 않아 전체 인기 상품을 조회합니다.", userId);
+            // 전체 인기 상품을 조회하는 로직 (현재는 ExcludingArtist로 빈 artistId를 넘기면 전체가 되도록 하거나, 별도 쿼리 필요)
+            // 임시로 다른 그룹 인기 상품 조회 로직을 그대로 사용 (필터링 없음)
+            myGroupItems = Collections.emptyList(); // 최애 아티스트 없으니 비워둠
+            otherGroupItems = groupBuyRepository.findPopularTitlesExcludingArtist(userId, null, ITEM_LIMIT); // 전체 인기 상품으로 대체
+        }
+
+        // TODO: 배너 로직 구현 필요 (현재는 더미)
+        List<HomeBanner> banners = List.of(
+            HomeBanner.builder().postId(1L).imageUrl("https://poti.s3.ap-northeast-2.amazonaws.com/banners/banner1.jpg").build(),
+            HomeBanner.builder().postId(2L).imageUrl("https://poti.s3.ap-northeast-2.amazonaws.com/banners/banner2.jpg").build()
+        );
+
+        return HomeResponse.builder()
+                .nickname(nickname)
+                .mainArtist(mainArtistName)
+                .myGroupItems(myGroupItems)
+                .otherGroupItems(otherGroupItems)
+                .banners(banners)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/image/controller/ImageController.java
+++ b/src/main/java/org/sopt/poti/domain/image/controller/ImageController.java
@@ -11,11 +11,10 @@ import org.sopt.poti.domain.image.dto.response.PresignedUrlResponse;
 import org.sopt.poti.global.common.ApiResponse;
 import org.sopt.poti.global.common.SuccessStatus;
 import org.sopt.poti.global.external.s3.S3Service;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,8 +27,7 @@ public class ImageController {
 
   @GetMapping("/presigned-url")
   @Operation(summary = "Presigned URL 다중 발급", description = "S3에 이미지를 업로드하기 위한 Presigned URL을 요청 수(count)만큼 발급받습니다.")
-  @ResponseStatus(HttpStatus.OK)
-  public ApiResponse<ImagePresignedUrlsResponse> getPresignedUrl(
+  public ResponseEntity<ApiResponse<ImagePresignedUrlsResponse>> getPresignedUrl(
       @ModelAttribute @Valid PresignedUrlRequest request
   ) {
     List<PresignedUrlResponse> urls = s3Service.getPresignedUrls(
@@ -37,6 +35,9 @@ public class ImageController {
         request.count(),
         request.extension()
     );
-    return ApiResponse.success(SuccessStatus.OK, ImagePresignedUrlsResponse.of(urls));
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            SuccessStatus.OK, ImagePresignedUrlsResponse.of(urls))
+    );
   }
 }

--- a/src/main/java/org/sopt/poti/global/common/ApiResponse.java
+++ b/src/main/java/org/sopt/poti/global/common/ApiResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import org.sopt.poti.global.error.ErrorStatus;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ApiResponse<T>(int code, String msg, T data) {
+public record ApiResponse<T>(int code, String message, T data) {
 
   public static <T> ApiResponse<T> success(SuccessStatus status, T data) {
     return new ApiResponse<>(


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #29 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
  1. 홈 화면 API (GET /api/v1/home)
   - 로그인한 사용자의 닉네임, 최애 아티스트, 추천 공동구매 리스트(myGroupItems, otherGroupItems), 배너 정보를 제공합니다.
   - QueryDSL을 활용하여 아티스트별 인기 상품(게시글 수 기준)을 집계하고, 최신 게시글의 이미지를 대표 이미지로 조회하는 복잡한 쿼리를 구현했습니다.
   - 최애 아티스트 유무에 따라 조회 로직을 분기 처리했습니다.

  2. 공동구매 게시글 등록 API (POST /api/v1/groupbuys)
   - 게시글 정보, 옵션 리스트, 배송 방법, 이미지 키 리스트를 받아 한 번에 저장합니다.
   - GroupBuyPost 엔티티와 하위 엔티티(GroupBuyOption, GroupBuyShipping, ItemImage) 간의 연관 관계를 CascadeType.ALL로 관리하여 일괄 저장합니다.
   - 이미지 순서 보장을 위해 sortOrder 필드를 추가하고 리스트 인덱스로 저장합니다.

  3. 상품명 자동완성 API (GET /api/v1/groupbuys/titles)
   - artistId와 keyword를 기반으로 해당 아티스트의 게시글 제목을 검색하여 자동완성 기능을 제공합니다.
   - DISTINCT를 사용하여 중복 없는 상품명 리스트를 반환합니다.

  4. S3 Presigned URL 발급 (GET /api/v1/images/presigned-url)
   - 이미지 업로드를 위한 Presigned URL을 발급하는 API를 구현했습니다.
   - GET 방식으로 변경하고 @ModelAttribute를 사용하여 쿼리 파라미터를 DTO로 받도록 수정했습니다.
   - 확장자 검증(@Pattern) 및 S3 예외 처리를 강화했습니다.

  5. 아키텍처 및 컨벤션 개선
   - Service 분리: GroupBuyService가 타 도메인 Repository를 직접 의존하지 않고 UserService, ArtistService 등을 주입받도록 구조를 개선했습니다.
   - Response Wrapper: 리스트 반환 시 Wrapper DTO(ImagePresignedUrlsResponse 등)로 감싸도록 컨벤션을 통일했습니다.
   - ResponseEntity 적용: 모든 컨트롤러의 반환 타입을 ResponseEntity<ApiResponse<T>>로 일관성 있게 변경했습니다.

## 📸 테스트 증명 (필수) 

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
   - QueryDSL: GroupBuyRepositoryCustom 인터페이스와 GroupBuyRepositoryImpl 구현체를 통해 복잡한 조회 쿼리를 작성했습니다.
   - Entity: GroupBuyPost에 title 인덱스를 추가하여 검색 성능을 고려했습니다. User 엔티티의 빌더 패턴을 개선했습니다.
   - Swagger: SwaggerConfig에서 add-mappings 설정을 제거하여 UI가 정상적으로 표시되도록 수정했습니다.

## ✅ 체크리스트
   - [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
   - [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
   - [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
   - [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 공동구매 게시물 생성 및 상품명 자동완성/추천 기능 추가
  * 홈 화면에 사용자 맞춤형 그룹구매 목록(즐겨찾는 아티스트 기반·기타 인기상품) 및 배너 노출 추가
  * 이미지 업로드용 presigned URL 반환 방식 개선

* **변경 사항**
  * API 응답 구조 및 메시지 필드명 정비, HTTP 응답 래핑 방식 통일 (ResponseEntity 사용)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->