### PR TITLE
[FEAT] 마이페이지 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepository.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepository.java
@@ -1,9 +1,16 @@
 package org.sopt.poti.domain.groupbuy.repository;
 
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface GroupBuyRepository extends JpaRepository<GroupBuyPost, Long>, GroupBuyRepositoryCustom {
+    int countByLeader_Id(Long userId);
+
+    int countByLeader_IdAndStatusIn(Long userId, List<GroupBuyPostStatus> statuses);
+
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -1,6 +1,7 @@
 package org.sopt.poti.domain.groupbuy.service;
 
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.artist.entity.Artist;
 import org.sopt.poti.domain.artist.entity.Member;
@@ -10,10 +11,7 @@ import org.sopt.poti.domain.delivery.entity.DeliveryMethod;
 import org.sopt.poti.domain.delivery.service.DeliveryService;
 import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyCreateRequest;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyCreateResponse;
-import org.sopt.poti.domain.groupbuy.entity.GroupBuyOption;
-import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
-import org.sopt.poti.domain.groupbuy.entity.GroupBuyShipping;
-import org.sopt.poti.domain.groupbuy.entity.ItemImage;
+import org.sopt.poti.domain.groupbuy.entity.*;
 import org.sopt.poti.domain.groupbuy.repository.GroupBuyRepository;
 import org.sopt.poti.domain.user.entity.User;
 import org.sopt.poti.domain.user.service.UserService;
@@ -27,60 +25,68 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GroupBuyService {
 
-  private final GroupBuyRepository groupBuyRepository;
-  private final UserService userService;
-  private final ArtistService artistService;
-  private final MemberService memberService;
-  private final DeliveryService deliveryService;
+    private final GroupBuyRepository groupBuyRepository;
+    private final UserService userService;
+    private final ArtistService artistService;
+    private final MemberService memberService;
+    private final DeliveryService deliveryService;
 
-  @Transactional
-  public GroupBuyCreateResponse createGroupBuyPost(Long userId, GroupBuyCreateRequest request) {
-    User leader = userService.getUserById(userId);
+    @Transactional
+    public GroupBuyCreateResponse createGroupBuyPost(Long userId, GroupBuyCreateRequest request) {
+        User leader = userService.getUserById(userId);
 
-    Artist artist = artistService.getById(request.artistId());
+        Artist artist = artistService.getById(request.artistId());
 
-    // GroupBuyPost 엔티티 생성
-    GroupBuyPost groupBuyPost = GroupBuyPost.create(
-        request.title(),
-        request.content(),
-        request.deadline(),
-        request.bankName(),
-        request.accountNumber(),
-        leader,
-        artist
-    );
+        // GroupBuyPost 엔티티 생성
+        GroupBuyPost groupBuyPost = GroupBuyPost.create(
+                request.title(),
+                request.content(),
+                request.deadline(),
+                request.bankName(),
+                request.accountNumber(),
+                leader,
+                artist
+        );
 
-    // 옵션 (GroupBuyOption) 연결
-    request.options().forEach(optionRequest -> {
-      Member member = memberService.getMemberById(optionRequest.memberId());
-      GroupBuyOption option = GroupBuyOption.create(optionRequest.price(), member);
-      groupBuyPost.addOption(option);
-    });
+        // 옵션 (GroupBuyOption) 연결
+        request.options().forEach(optionRequest -> {
+            Member member = memberService.getMemberById(optionRequest.memberId());
+            GroupBuyOption option = GroupBuyOption.create(optionRequest.price(), member);
+            groupBuyPost.addOption(option);
+        });
 
-    // 배송 방법 (GroupBuyShipping) 연결
-    request.shippings().forEach(shippingRequest -> {
-      DeliveryMethod deliveryMethod = deliveryService.getDeliveryMethodById(
-          shippingRequest.deliveryMethodId());
-      GroupBuyShipping shipping = GroupBuyShipping.create(shippingRequest.price(), deliveryMethod);
-      groupBuyPost.addShipping(shipping);
-    });
+        // 배송 방법 (GroupBuyShipping) 연결
+        request.shippings().forEach(shippingRequest -> {
+            DeliveryMethod deliveryMethod = deliveryService.getDeliveryMethodById(
+                    shippingRequest.deliveryMethodId());
+            GroupBuyShipping shipping = GroupBuyShipping.create(shippingRequest.price(), deliveryMethod);
+            groupBuyPost.addShipping(shipping);
+        });
 
-    // 이미지 (ItemImage) 연결
-    List<String> imageUrls = request.imageUrls();
-    for (int i = 0; i < imageUrls.size(); i++) {
-      ItemImage image = ItemImage.create(imageUrls.get(i), i);
-      groupBuyPost.addImage(image);
+        // 이미지 (ItemImage) 연결
+        List<String> imageUrls = request.imageUrls();
+        for (int i = 0; i < imageUrls.size(); i++) {
+            ItemImage image = ItemImage.create(imageUrls.get(i), i);
+            groupBuyPost.addImage(image);
+        }
+
+        // 최종 저장 (CascadeType.ALL 덕분에 한 번에 다 저장됨)
+        groupBuyRepository.save(groupBuyPost);
+
+        return GroupBuyCreateResponse.of(groupBuyPost.getId());
     }
 
-    // 최종 저장 (CascadeType.ALL 덕분에 한 번에 다 저장됨)
-    groupBuyRepository.save(groupBuyPost);
+    // 상품명 자동완성
+    public List<String> searchTitles(Long artistId, String keyword) {
+        Pageable pageable = PageRequest.of(0, 5); // 최대 5개만 조회
+        return groupBuyRepository.findTitlesByKeyword(artistId, keyword, pageable.getPageSize());
+    }
 
-    return GroupBuyCreateResponse.of(groupBuyPost.getId());
-  }
+    public int countByLeader_Id(Long userId) {
+        return groupBuyRepository.countByLeader_Id(userId);
+    }
 
-  // 상품명 자동완성
-  public List<String> searchTitles(Long artistId, String keyword) {
-    Pageable pageable = PageRequest.of(0, 5); // 최대 5개만 조회
-    return groupBuyRepository.findTitlesByKeyword(artistId, keyword, pageable.getPageSize());
-  }
+    public int countByLeader_IdAndStatusIn(Long userId, List<GroupBuyPostStatus> statuses) {
+        return groupBuyRepository.countByLeader_IdAndStatusIn(userId, statuses);
+    }
 }

--- a/src/main/java/org/sopt/poti/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/sopt/poti/domain/order/repository/OrderRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.poti.domain.order.repository;
+
+import java.util.List;
+import org.sopt.poti.domain.order.entity.Order;
+import org.sopt.poti.domain.order.entity.OrderStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    int countByUser_Id(Long userId);
+
+    int countByUser_IdAndStatusIn(Long userId, List<OrderStatus> statuses);
+}

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
@@ -1,0 +1,25 @@
+package org.sopt.poti.domain.order.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.order.entity.OrderStatus;
+import org.sopt.poti.domain.order.repository.OrderRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    public int countByUser_Id(Long userId) {
+        return orderRepository.countByUser_Id(userId);
+    }
+
+    public int countByUser_IdAndStatusIn(Long userId, List<OrderStatus> statuses) {
+        return orderRepository.countByUser_IdAndStatusIn(userId, statuses);
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/user/controller/MyPageController.java
+++ b/src/main/java/org/sopt/poti/domain/user/controller/MyPageController.java
@@ -1,0 +1,29 @@
+package org.sopt.poti.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.user.dto.response.MyPageResponse;
+import org.sopt.poti.domain.user.service.MyPageService;
+import org.sopt.poti.global.common.ApiResponse;
+import org.sopt.poti.global.common.SuccessStatus;
+import org.sopt.poti.global.security.UserPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping("/mypage")
+    public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        MyPageResponse data = myPageService.getMyPage(userPrincipal.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, data));
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/user/controller/MyPageController.java
+++ b/src/main/java/org/sopt/poti/domain/user/controller/MyPageController.java
@@ -1,5 +1,7 @@
 package org.sopt.poti.domain.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.user.dto.response.MyPageResponse;
 import org.sopt.poti.domain.user.service.MyPageService;
@@ -15,11 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
+@Tag(name = "MyPage", description = "마이페이지 관련 API")
 public class MyPageController {
 
     private final MyPageService myPageService;
 
     @GetMapping("/mypage")
+    @Operation(summary = "마이페이지 조회", description = "로그인한 유저 본인의 마이페이지를 조회합니다.")
     public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {

--- a/src/main/java/org/sopt/poti/domain/user/dto/response/MyPageResponse.java
+++ b/src/main/java/org/sopt/poti/domain/user/dto/response/MyPageResponse.java
@@ -11,6 +11,7 @@ public record MyPageResponse(
         String activityMessage,
         LocalDate joinedAt,
         Boolean hasFavoriteArtist,
+        String FavoriteArtistName,
         Summary participationSummary,
         Summary recruitSummary
 ) {

--- a/src/main/java/org/sopt/poti/domain/user/dto/response/MyPageResponse.java
+++ b/src/main/java/org/sopt/poti/domain/user/dto/response/MyPageResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.poti.domain.user.dto.response;
+
+import java.time.LocalDate;
+
+public record MyPageResponse(
+        Long userId,
+        String nickname,
+        String email,
+        String profileImageUrl,
+        Double ratingAvg,
+        String activityMessage,
+        LocalDate joinedAt,
+        Boolean hasFavoriteArtist,
+        Summary participationSummary,
+        Summary recruitSummary
+) {
+    public record Summary(
+            Integer total,
+            Integer inProgress,
+            Integer completed
+    ) {}
+}

--- a/src/main/java/org/sopt/poti/domain/user/service/ActivityMessageResolver.java
+++ b/src/main/java/org/sopt/poti/domain/user/service/ActivityMessageResolver.java
@@ -1,0 +1,27 @@
+package org.sopt.poti.domain.user.service;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Component
+public class ActivityMessageResolver {
+
+    public String resolve(LocalDateTime lastActiveAt) {
+        if (lastActiveAt == null) return "최근 한 달 이내 활동하지 않음";
+
+        long days = ChronoUnit.DAYS.between(
+                lastActiveAt.toLocalDate(),
+                LocalDate.now()
+        );
+
+        if (days <= 3) return "최근 3일 이내 활동";
+        if (days <= 7) return "최근 일주일 이내 활동";
+        if (days <= 14) return "최근 2주 이내 활동";
+        if (days <= 21) return "최근 3주 이내 활동";
+        if (days <= 30) return "최근 한 달 이내 활동";
+        return "최근 한 달 이내 활동하지 않음";
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/user/service/MyPageService.java
+++ b/src/main/java/org/sopt/poti/domain/user/service/MyPageService.java
@@ -1,8 +1,6 @@
 package org.sopt.poti.domain.user.service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
@@ -24,13 +22,14 @@ public class MyPageService {
     private final UserRepository userRepository;
     private final OrderService orderService;
     private final GroupBuyService groupBuyService;
+    private final ActivityMessageResolver activityMessageResolver;
 
     @Transactional(readOnly = true)
     public MyPageResponse getMyPage(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorStatus.USER_NOT_FOUND));
 
-        String activityMessage = resolveActivityMessage(user.getLastActiveAt());
+        String activityMessage = activityMessageResolver.resolve(user.getLastActiveAt());
         LocalDate joinedAt = user.getCreatedAt().toLocalDate();
         boolean hasFavoriteArtist = (user.getFavoriteArtist() != null);
 
@@ -80,18 +79,5 @@ public class MyPageService {
                 participation,
                 recruit
         );
-    }
-
-    private String resolveActivityMessage(LocalDateTime lastActiveAt) {
-        if (lastActiveAt == null) return "최근 한 달 이내 활동하지 않음";
-
-        long days = ChronoUnit.DAYS.between(lastActiveAt.toLocalDate(), LocalDate.now());
-
-        if (days <= 3) return "최근 3일 이내 활동";
-        if (days <= 7) return "최근 일주일 이내 활동";
-        if (days <= 14) return "최근 2주 이내 활동";
-        if (days <= 21) return "최근 3주 이내 활동";
-        if (days <= 30) return "최근 한 달 이내 활동";
-        return "최근 한 달 이내 활동하지 않음";
     }
 }

--- a/src/main/java/org/sopt/poti/domain/user/service/MyPageService.java
+++ b/src/main/java/org/sopt/poti/domain/user/service/MyPageService.java
@@ -2,6 +2,7 @@ package org.sopt.poti.domain.user.service;
 
 import java.time.LocalDate;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
 import org.sopt.poti.domain.groupbuy.service.GroupBuyService;
@@ -32,6 +33,10 @@ public class MyPageService {
         String activityMessage = activityMessageResolver.resolve(user.getLastActiveAt());
         LocalDate joinedAt = user.getCreatedAt().toLocalDate();
         boolean hasFavoriteArtist = (user.getFavoriteArtist() != null);
+
+        String favoriteArtistName = hasFavoriteArtist
+                ? user.getFavoriteArtist().getName()
+                : null;
 
         int pTotal = orderService.countByUser_Id(userId);
 
@@ -76,6 +81,7 @@ public class MyPageService {
                 activityMessage,
                 joinedAt,
                 hasFavoriteArtist,
+                favoriteArtistName,
                 participation,
                 recruit
         );

--- a/src/main/java/org/sopt/poti/domain/user/service/MyPageService.java
+++ b/src/main/java/org/sopt/poti/domain/user/service/MyPageService.java
@@ -6,9 +6,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
-import org.sopt.poti.domain.groupbuy.repository.GroupBuyRepository;
+import org.sopt.poti.domain.groupbuy.service.GroupBuyService;
 import org.sopt.poti.domain.order.entity.OrderStatus;
-import org.sopt.poti.domain.order.repository.OrderRepository;
+import org.sopt.poti.domain.order.service.OrderService;
 import org.sopt.poti.domain.user.dto.response.MyPageResponse;
 import org.sopt.poti.domain.user.entity.User;
 import org.sopt.poti.domain.user.repository.UserRepository;
@@ -22,8 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class MyPageService {
 
     private final UserRepository userRepository;
-    private final OrderRepository orderRepository;
-    private final GroupBuyRepository groupBuyRepository;
+    private final OrderService orderService;
+    private final GroupBuyService groupBuyService;
 
     @Transactional(readOnly = true)
     public MyPageResponse getMyPage(Long userId) {
@@ -34,7 +34,7 @@ public class MyPageService {
         LocalDate joinedAt = user.getCreatedAt().toLocalDate();
         boolean hasFavoriteArtist = (user.getFavoriteArtist() != null);
 
-        int pTotal = orderRepository.countByUser_Id(userId);
+        int pTotal = orderService.countByUser_Id(userId);
 
         List<OrderStatus> pInProgressStatuses = List.of(
                 OrderStatus.WAIT_PAY,
@@ -43,28 +43,28 @@ public class MyPageService {
                 OrderStatus.READY,
                 OrderStatus.SHIPPED
         );
-        int pInProgress = orderRepository.countByUser_IdAndStatusIn(userId, pInProgressStatuses);
+        int pInProgress = orderService.countByUser_IdAndStatusIn(userId, pInProgressStatuses);
 
         List<OrderStatus> pCompletedStatuses = List.of(OrderStatus.DELIVERED);
-        int pCompleted = orderRepository.countByUser_IdAndStatusIn(userId, pCompletedStatuses);
+        int pCompleted = orderService.countByUser_IdAndStatusIn(userId, pCompletedStatuses);
 
         MyPageResponse.Summary participation = new MyPageResponse.Summary(pTotal, pInProgress, pCompleted);
 
-        int rTotal = groupBuyRepository.countByLeader_Id(userId);
+        int rTotal = groupBuyService.countByLeader_Id(userId);
 
         List<GroupBuyPostStatus> rInProgressStatuses = List.of(
                 GroupBuyPostStatus.RECRUITING,
                 GroupBuyPostStatus.PAYMENT_DONE,
                 GroupBuyPostStatus.SHIPPING
         );
-        int rInProgress = groupBuyRepository.countByLeader_IdAndStatusIn(userId, rInProgressStatuses);
+        int rInProgress = groupBuyService.countByLeader_IdAndStatusIn(userId, rInProgressStatuses);
 
         List<GroupBuyPostStatus> rCompletedStatuses = List.of(
                 GroupBuyPostStatus.CLOSED,
                 GroupBuyPostStatus.DELIVERED,
                 GroupBuyPostStatus.COMPLETED
         );
-        int rCompleted = groupBuyRepository.countByLeader_IdAndStatusIn(userId, rCompletedStatuses);
+        int rCompleted = groupBuyService.countByLeader_IdAndStatusIn(userId, rCompletedStatuses);
 
         MyPageResponse.Summary recruit = new MyPageResponse.Summary(rTotal, rInProgress, rCompleted);
 

--- a/src/main/java/org/sopt/poti/domain/user/service/MyPageService.java
+++ b/src/main/java/org/sopt/poti/domain/user/service/MyPageService.java
@@ -1,0 +1,97 @@
+package org.sopt.poti.domain.user.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
+import org.sopt.poti.domain.groupbuy.repository.GroupBuyRepository;
+import org.sopt.poti.domain.order.entity.OrderStatus;
+import org.sopt.poti.domain.order.repository.OrderRepository;
+import org.sopt.poti.domain.user.dto.response.MyPageResponse;
+import org.sopt.poti.domain.user.entity.User;
+import org.sopt.poti.domain.user.repository.UserRepository;
+import org.sopt.poti.global.error.BusinessException;
+import org.sopt.poti.global.error.ErrorStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final OrderRepository orderRepository;
+    private final GroupBuyRepository groupBuyRepository;
+
+    @Transactional(readOnly = true)
+    public MyPageResponse getMyPage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.USER_NOT_FOUND));
+
+        String activityMessage = resolveActivityMessage(user.getLastActiveAt());
+        LocalDate joinedAt = user.getCreatedAt().toLocalDate();
+        boolean hasFavoriteArtist = (user.getFavoriteArtist() != null);
+
+        int pTotal = orderRepository.countByUser_Id(userId);
+
+        List<OrderStatus> pInProgressStatuses = List.of(
+                OrderStatus.WAIT_PAY,
+                OrderStatus.WAIT_PAY_CHECK,
+                OrderStatus.PAID,
+                OrderStatus.READY,
+                OrderStatus.SHIPPED
+        );
+        int pInProgress = orderRepository.countByUser_IdAndStatusIn(userId, pInProgressStatuses);
+
+        List<OrderStatus> pCompletedStatuses = List.of(OrderStatus.DELIVERED);
+        int pCompleted = orderRepository.countByUser_IdAndStatusIn(userId, pCompletedStatuses);
+
+        MyPageResponse.Summary participation = new MyPageResponse.Summary(pTotal, pInProgress, pCompleted);
+
+        int rTotal = groupBuyRepository.countByLeader_Id(userId);
+
+        List<GroupBuyPostStatus> rInProgressStatuses = List.of(
+                GroupBuyPostStatus.RECRUITING,
+                GroupBuyPostStatus.PAYMENT_DONE,
+                GroupBuyPostStatus.SHIPPING
+        );
+        int rInProgress = groupBuyRepository.countByLeader_IdAndStatusIn(userId, rInProgressStatuses);
+
+        List<GroupBuyPostStatus> rCompletedStatuses = List.of(
+                GroupBuyPostStatus.CLOSED,
+                GroupBuyPostStatus.DELIVERED,
+                GroupBuyPostStatus.COMPLETED
+        );
+        int rCompleted = groupBuyRepository.countByLeader_IdAndStatusIn(userId, rCompletedStatuses);
+
+        MyPageResponse.Summary recruit = new MyPageResponse.Summary(rTotal, rInProgress, rCompleted);
+
+        return new MyPageResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getProfileImageUrl(),
+                user.getRatingAvg(),
+                activityMessage,
+                joinedAt,
+                hasFavoriteArtist,
+                participation,
+                recruit
+        );
+    }
+
+    private String resolveActivityMessage(LocalDateTime lastActiveAt) {
+        if (lastActiveAt == null) return "최근 한 달 이내 활동하지 않음";
+
+        long days = ChronoUnit.DAYS.between(lastActiveAt.toLocalDate(), LocalDate.now());
+
+        if (days <= 3) return "최근 3일 이내 활동";
+        if (days <= 7) return "최근 일주일 이내 활동";
+        if (days <= 14) return "최근 2주 이내 활동";
+        if (days <= 21) return "최근 3주 이내 활동";
+        if (days <= 30) return "최근 한 달 이내 활동";
+        return "최근 한 달 이내 활동하지 않음";
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/poti/domain/user/service/UserService.java
@@ -5,8 +5,6 @@ import org.sopt.poti.domain.artist.service.ArtistService;
 import org.sopt.poti.domain.user.dto.request.UserOnboardingRequest;
 import org.sopt.poti.domain.user.dto.response.UserOnboardingResponse;
 import org.sopt.poti.domain.artist.entity.Artist;
-import org.sopt.poti.domain.user.dto.request.UserOnboardingRequest;
-import org.sopt.poti.domain.user.dto.response.UserOnboardingResponse;
 import org.sopt.poti.domain.user.entity.User;
 import org.sopt.poti.domain.user.repository.UserRepository;
 import org.sopt.poti.global.error.BusinessException;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #26

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
**마이페이지 정보 조회**
- 사용자가 마이페이지에서 자신의 정보 및 구매/모집 요약 정보를 확인할 수 있는 API
- GET /api/v1/users/mypage 엔드포인트 추가
- MyPageResponse DTO를 통해 유저 기본 정보 + 활동 메시지 + 요약 통계를 한 번에 반환

**최근 활동일 메시지 제공**
- 사용자의 lastActiveAt을 기준으로 “최근 활동” 문구가 자동으로 계산되어 내려가도록 함
- lastActiveAt이 null인 경우 "최근 한 달 이내 활동하지 않음" 반
- ChronoUnit.DAYS를 사용해 현재 날짜 기준 경과 일수 계산

**구매 내역 요약**
- 주문 상태 기준으로 요약을 계산
- total: user의 전체 주문 수
- inProgress: WAIT_PAY, WAIT_PAY_CHECK, PAID, READY, SHIPPED
- completed: DELIVERED

**모집 내역 요약**
- 공구글 상태 기준으로 요약을 계산
- total: 내가 총대인 공구글 전체 수
- inProgress: RECRUITING, PAYMENT_DONE, SHIPPING
- completed: CLOSED, DELIVERED, COMPLETED
## 📸 테스트 증명 (필수) 

- 더미데이터로 API 테스트
<img width="2372" height="1101" alt="스크린샷 2026-01-13 044016" src="https://github.com/user-attachments/assets/3b3688c1-770b-4724-b4a3-be3a99df1aaa" />
<br>

- 더미데이터로 활동일 조건 잘 돌아가는것 확인

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- `3일 이내 활동/미활동`을 판단하는 기존 로직에서

```
최근 3일 이내 활동
최근 일주일 이내 활동
최근 2주 이내 활동
최근 3주 이내 활동
최근 한 달 이내 활동
최근 한 달 이내 활동하지 않음
```
의 기준으로 바뀜.
코드에 이것 적용

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지 추가 — 프로필, 평점, 활동 메시지, 가입일, 즐겨찾는 아티스트명, 참여/모집 요약 제공 (GET mypage)
  * 활동 메시지 생성기 추가 — 최근 활동을 인간 친화적 문구로 표시
  * 사용자별 주문·모집 통계 조회 기능 추가 — 전체/진행/완료 등 상태별 집계 지원
  * 그룹구매 제목 검색(키워드 기반, 상위 결과 5개) 기능 추가

* **잡무(Chore)**
  * 불필요한 임포트 정리 및 포맷 정리 완료

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->