### PR TITLE
[FEAT] 아티스트 리스트 조회 API

### DIFF
--- a/src/main/java/org/sopt/poti/domain/artist/controller/ArtistController.java
+++ b/src/main/java/org/sopt/poti/domain/artist/controller/ArtistController.java
@@ -1,0 +1,28 @@
+package org.sopt.poti.domain.artist.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.artist.dto.response.ArtistListResponse;
+import org.sopt.poti.domain.artist.service.ArtistService;
+import org.sopt.poti.global.common.ApiResponse;
+import org.sopt.poti.global.common.SuccessStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Artists", description = "아티스트 관련 API")
+@RequestMapping("/api/v1/artists")
+public class ArtistController {
+    private final ArtistService artistService;
+
+    @GetMapping
+    @Operation(summary = "아티스트 리스트 조회", description = "온보딩 최애 아티스트 선택시 사용되는 아티스트 리스트입니다.")
+    public ResponseEntity<ApiResponse<ArtistListResponse>> getArtists() {
+        ArtistListResponse data = artistService.getArtists();
+        return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, data));
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/artist/dto/response/ArtistListResponse.java
+++ b/src/main/java/org/sopt/poti/domain/artist/dto/response/ArtistListResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.poti.domain.artist.dto.response;
+
+
+import java.util.List;
+
+public record ArtistListResponse(
+        List<ArtistItemResponse> artists
+) {
+    public record ArtistItemResponse(
+            Long artistId,
+            String name,
+            String logoImageUrl
+    ) {}
+}

--- a/src/main/java/org/sopt/poti/domain/artist/service/ArtistService.java
+++ b/src/main/java/org/sopt/poti/domain/artist/service/ArtistService.java
@@ -1,12 +1,15 @@
 package org.sopt.poti.domain.artist.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.artist.dto.response.ArtistListResponse;
 import org.sopt.poti.domain.artist.entity.Artist;
 import org.sopt.poti.domain.artist.repository.ArtistRepository;
 import org.sopt.poti.global.error.BusinessException;
 import org.sopt.poti.global.error.ErrorStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,5 +21,19 @@ public class ArtistService {
     public Artist getById(Long artistId) {
         return artistRepository.findById(artistId)
                 .orElseThrow(() -> new BusinessException(ErrorStatus.ARTIST_NOT_FOUND));
+    }
+
+    public ArtistListResponse getArtists() {
+        List<Artist> artists = artistRepository.findAll();
+
+        return new ArtistListResponse(
+                artists.stream()
+                        .map(a -> new ArtistListResponse.ArtistItemResponse(
+                                a.getId(),
+                                a.getName(),
+                                a.getLogoImageUrl()
+                        ))
+                        .toList()
+        );
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #37 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
**아티스트 리스트 조회 API 구현**
- 온보딩 과정에서 사용자가 최애 아티스트를 선택할 수 있도록, 아티스트 전체 목록을 조회하는 API를 구현했습니다.

**아티스트 리스트 조회 엔드포인트 추가**
- GET /api/v1/artists 엔드포인트를 추가했습니다.
- 아티스트 전체 목록을 조회하여 응답으로 반환합니다.
- Swagger 문서화를 위해 @Tag, @Operation을 적용했습니다.

**응답 DTO 정의**
- 아티스트 목록 응답을 위한 ArtistListResponse DTO를 신규 생성했습니다.

**서비스 로직 구현**
- ArtistRepository.findAll()을 통해 DB에 저장된 모든 아티스트를 조회합니다.
- 조회한 엔티티를 스트림으로 변환하여 응답 DTO로 매핑한 후 반환합니다.
- 조회 전용 로직이므로 @Transactional(readOnly = true)를 적용했습니다.

## 📸 테스트 증명 (필수) 
- 아티스트 조회 API 테스트 성공
<img width="1076" height="1264" alt="image" src="https://github.com/user-attachments/assets/717e56b3-5f65-476c-ba5d-fdf37079137e" />

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 아티스트 목록 조회 API 엔드포인트 추가 - 모든 아티스트의 정보(ID, 이름, 로고 이미지)를 조회할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->