### PR TITLE
[FEAT] 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/org/sopt/poti/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/poti/domain/auth/controller/AuthController.java
@@ -5,7 +5,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.auth.dto.request.AuthRequest;
+import org.sopt.poti.domain.auth.dto.request.TokenReissueRequest;
 import org.sopt.poti.domain.auth.dto.response.AuthResponse;
+import org.sopt.poti.domain.auth.dto.response.TokenReissueResponse;
 import org.sopt.poti.domain.auth.service.AuthService;
 import org.sopt.poti.global.common.ApiResponse;
 import org.sopt.poti.global.common.SuccessStatus;
@@ -28,6 +30,17 @@ public class AuthController {
   public ResponseEntity<ApiResponse<AuthResponse>> socialLogin(
       @RequestBody @Valid AuthRequest request) {
     AuthResponse response = authService.socialLogin(request);
+    return ResponseEntity.ok(
+        ApiResponse.success(SuccessStatus.OK, response)
+    );
+  }
+
+  @PostMapping("/reissue")
+  @Operation(summary = "토큰 재발급", description = "Refresh Token을 사용하여 Access Token 및 Refresh Token을 재발급합니다.")
+  public ResponseEntity<ApiResponse<TokenReissueResponse>> reissue(
+      @RequestBody @Valid TokenReissueRequest request
+  ) {
+    TokenReissueResponse response = authService.reissue(request);
     return ResponseEntity.ok(
         ApiResponse.success(SuccessStatus.OK, response)
     );

--- a/src/main/java/org/sopt/poti/domain/auth/dto/request/TokenReissueRequest.java
+++ b/src/main/java/org/sopt/poti/domain/auth/dto/request/TokenReissueRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.poti.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenReissueRequest(
+    @NotBlank(message = "Refresh Token은 필수입니다.")
+    String refreshToken
+) {
+}

--- a/src/main/java/org/sopt/poti/domain/auth/dto/response/TokenReissueResponse.java
+++ b/src/main/java/org/sopt/poti/domain/auth/dto/response/TokenReissueResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.poti.domain.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TokenReissueResponse(
+    String accessToken,
+    String refreshToken
+) {
+}

--- a/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
@@ -5,7 +5,9 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.poti.domain.auth.dto.request.AuthRequest;
+import org.sopt.poti.domain.auth.dto.request.TokenReissueRequest;
 import org.sopt.poti.domain.auth.dto.response.AuthResponse;
+import org.sopt.poti.domain.auth.dto.response.TokenReissueResponse;
 import org.sopt.poti.domain.auth.entity.RefreshToken;
 import org.sopt.poti.domain.auth.repository.RefreshTokenRepository;
 import org.sopt.poti.domain.user.entity.SocialType;
@@ -96,6 +98,41 @@ public class AuthService {
         .refreshToken(refreshToken)
         .isNewUser(isNewUser)
         .userId(user.getId())
+        .build();
+  }
+
+  @Transactional
+  public TokenReissueResponse reissue(TokenReissueRequest request) {
+    // Refresh Token 유효성 검증
+    String oldRefreshToken = request.refreshToken();
+    jwtTokenProvider.validateToken(oldRefreshToken);
+
+    // Refresh Token에서 userId 추출
+    Long userId = jwtTokenProvider.getUserIdFromToken(oldRefreshToken);
+
+    // Redis에서 저장된 Refresh Token 조회 및 일치 여부 확인
+    RefreshToken storedRefreshToken = refreshTokenRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.INVALID_TOKEN)); // Redis에 토큰 없음
+
+    if (!storedRefreshToken.getRefreshToken().equals(oldRefreshToken)) {
+      throw new BusinessException(ErrorStatus.INVALID_TOKEN); // 토큰 불일치
+    }
+
+    // 새로운 Access Token 및 Refresh Token 발급
+    String newAccessToken = jwtTokenProvider.createAccessToken(userId);
+    String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+    // Redis 업데이트 (기존 토큰 삭제 후 새 토큰 저장)
+    refreshTokenRepository.delete(storedRefreshToken); // 기존 토큰 삭제
+    refreshTokenRepository.save(RefreshToken.builder()
+        .userId(userId)
+        .refreshToken(newRefreshToken)
+        .ttl(refreshTokenValidity / 1000)
+        .build());
+
+    return TokenReissueResponse.builder()
+        .accessToken(newAccessToken)
+        .refreshToken(newRefreshToken)
         .build();
   }
 

--- a/src/main/java/org/sopt/poti/global/dev/DevController.java
+++ b/src/main/java/org/sopt/poti/global/dev/DevController.java
@@ -3,17 +3,20 @@ package org.sopt.poti.global.dev;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.auth.entity.RefreshToken;
+import org.sopt.poti.domain.auth.repository.RefreshTokenRepository;
 import org.sopt.poti.domain.user.entity.User;
 import org.sopt.poti.domain.user.service.UserService;
 import org.sopt.poti.global.common.ApiResponse;
 import org.sopt.poti.global.common.SuccessStatus;
+import org.sopt.poti.global.security.jwt.JwtTokenProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.sopt.poti.global.security.jwt.JwtTokenProvider;
 
 @RestController
 @RequestMapping("/dev")
@@ -24,6 +27,10 @@ public class DevController {
 
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository; // RefreshTokenRepository 주입
+
+    @Value("${jwt.refresh-token-validity}") // Refresh Token 유효기간 주입
+    private long refreshTokenValidity;
 
     @GetMapping("/login")
     @Operation(summary = "개발자용 토큰 발급 (userId=1)", description = "개발 테스트를 위해 1번 유저의 토큰을 즉시 발급합니다. (로컬/Dev 환경 전용)")
@@ -34,6 +41,13 @@ public class DevController {
 
         String accessToken = jwtTokenProvider.createAccessToken(user.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+        // Redis에 Refresh Token 저장
+        refreshTokenRepository.save(RefreshToken.builder()
+                .userId(user.getId())
+                .refreshToken(refreshToken)
+                .ttl(refreshTokenValidity / 1000)
+                .build());
 
         DevTokenResponseDto responseDto = DevTokenResponseDto.builder()
                 .accessToken(accessToken)

--- a/src/main/java/org/sopt/poti/global/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/poti/global/security/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
       "/swagger-ui/**", // Swagger 문서 관련
       "/v3/api-docs/**",
       "/favicon.ico",
-      "/dev/login" // 개발자용 자동 로그인 (토큰 발급)
+      "/dev/login", // 개발자용 자동 로그인 (토큰 발급)
   };
 
   @Bean


### PR DESCRIPTION
##  📌 관련 이슈
  <!-- 관련 이슈를 적어주세요. -->
   - close #49 

##  ✨ 변경 사항
  <!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

  1. 토큰 재발급 (Reissue) API 개선
   - Access/Refresh Token 재발급: /api/v1/auth/reissue 엔드포인트를 통해 Refresh Token을 검증하고 새로운 Access Token과 Refresh Token을 발급(RTR)하도록 구현했습니다.
   - Refresh Token 저장 로직 추가: DevController와 AuthService에서 로그인 성공 시 Refresh Token을 Redis에 저장하도록 수정하여, 재발급 API 테스트가 가능하도록 했습니다.
   - 예외 처리: 만료된 Refresh Token이나 일치하지 않는 토큰에 대한 예외 처리를 강화했습니다.

  2. 설정(Config) 추가 및 수정
   - QueryDSL: QueryDslConfig를 추가하여 JPAQueryFactory 빈을 등록, QueryDSL을 사용할 수 있도록 설정했습니다.
   - Redis: RedisConfig를 추가하고 @EnableRedisRepositories를 적용하여 Redis Repository가 정상적으로 동작하도록 설정했습니다.
   - Security: SecurityConfig에 /api/v1/auth/reissue를 WHITE_LIST에 추가하여 인증 없이 접근 가능하도록 설정했습니다.

##  📸 테스트 증명 (필수)
- 토큰 재발급
<img width="2028" height="1458" alt="image" src="https://github.com/user-attachments/assets/da209726-6ab4-47b1-9984-753c4f786e54" />


##  📚 리뷰어 참고 사항
  <!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
   - RTR: 보안 강화를 위해 재발급 시 Refresh Token도 함께 갱신(Rotation)하는 방식을 채택했습니다.

##  ✅ 체크리스트
   - [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
   - [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
   - [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
   - [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 토큰 재발급 API 엔드포인트 추가: 갱신 토큰을 통해 새로운 인증 토큰을 발급받을 수 있습니다.
  * 토큰 검증 및 재발급 기능 구현: 기존 갱신 토큰 검증 후 새로운 토큰 쌍을 발급합니다.

* **Bug Fixes**
  * 보안 설정의 구문 에러 수정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->