### PR TITLE
[FEAT] 상품별 분철 팟 목록 조회 API 구현 및 명세 반영

### DIFF
--- a/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
@@ -7,18 +7,23 @@ import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyCreateRequest;
+import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyListRequest;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyCreateResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyListResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyTitlesResponse;
 import org.sopt.poti.domain.groupbuy.service.GroupBuyService;
 import org.sopt.poti.global.common.ApiResponse;
 import org.sopt.poti.global.common.SuccessStatus;
 import org.sopt.poti.global.security.UserPrincipal;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -73,5 +78,17 @@ public class GroupBuyController {
         userPrincipal.getUserId(), postId);
 
     return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, groupBuyDetail));
+  }
+
+  @GetMapping("/pots")
+  @Operation(summary = "상품별 분철 팟 목록 조회", description = "특정 아티스트의 특정 상품명에 해당하는 분철 팟(게시글) 목록을 필터링 및 정렬하여 조회합니다. (남아있는 멤버 필터링, 평점순, 마감임박순 정렬)")
+  public ResponseEntity<ApiResponse<GroupBuyListResponse>> getGroupBuyPotList(
+      @ModelAttribute @Valid GroupBuyListRequest request,
+      @PageableDefault(size = 10) Pageable pageable
+  ) {
+    GroupBuyListResponse response = groupBuyService.getGroupBuyListByPostTitle(request, pageable);
+    return ResponseEntity.ok(
+        ApiResponse.success(SuccessStatus.OK, response)
+    );
   }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyListRequest.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyListRequest.java
@@ -1,0 +1,25 @@
+package org.sopt.poti.domain.groupbuy.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public record GroupBuyListRequest(
+    @NotBlank(message = "상품명(title)은 필수입니다.")
+    String title,
+
+    @NotNull(message = "아티스트 ID는 필수입니다.")
+    Long artistId,
+
+    List<Long> memberIds, // 필터링할 멤버 ID 리스트 (없으면 null)
+
+    String sort // LATEST, DEADLINE, RATING
+) {
+    // Compact Constructor
+    public GroupBuyListRequest {
+        if (title != null) {
+            title = title.trim(); // 여기서 앞뒤 공백 제거
+        }
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyListRequest.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyListRequest.java
@@ -3,7 +3,6 @@ package org.sopt.poti.domain.groupbuy.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import org.springframework.data.domain.Pageable;
 
 public record GroupBuyListRequest(
     @NotBlank(message = "상품명(title)은 필수입니다.")
@@ -16,10 +15,10 @@ public record GroupBuyListRequest(
 
     String sort // LATEST, DEADLINE, RATING
 ) {
-    // Compact Constructor
-    public GroupBuyListRequest {
-        if (title != null) {
-            title = title.trim(); // 여기서 앞뒤 공백 제거
-        }
+
+  public GroupBuyListRequest {
+    if (title != null) {
+      title = title.trim(); // 여기서 앞뒤 공백 제거
     }
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyListRequest.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyListRequest.java
@@ -1,18 +1,23 @@
 package org.sopt.poti.domain.groupbuy.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record GroupBuyListRequest(
+    @Schema(description = "분철글 제목 (상품명)", example = "NewJeans How Sweet")
     @NotBlank(message = "상품명(title)은 필수입니다.")
     String title,
 
+    @Schema(description = "아티스트 식별자", example = "1")
     @NotNull(message = "아티스트 ID는 필수입니다.")
     Long artistId,
 
+    @Schema(description = "남아있는 멤버들 필터링 리스트 (선택 사항)", example = "[1, 2]")
     List<Long> memberIds, // 필터링할 멤버 ID 리스트 (없으면 null)
 
+    @Schema(description = "정렬 조건 (LATEST, DEADLINE, RATING)", example = "LATEST")
     String sort // LATEST, DEADLINE, RATING
 ) {
 

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyDetailResponse.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyDetailResponse.java
@@ -45,7 +45,7 @@ public record GroupBuyDetailResponse(
   @Builder
   public record UploaderResponse(
       Long userId,
-      String nickName,
+      String nickname,
       String profileImage,
       Double rating,
       Integer reviewCount
@@ -56,7 +56,7 @@ public record GroupBuyDetailResponse(
   @Builder
   public record ParticipantResponse(
       Long userId,
-      String nickName,
+      String nickname,
       String profileImage,
       Double rating,
       List<String> selectedMembers

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyListResponse.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyListResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.poti.domain.groupbuy.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record GroupBuyListResponse(
+    @Schema(description = "상품명", example = "NewJeans How Sweet")
+    String postTitle,
+    @Schema(description = "아티스트 ID", example = "1")
+    Long artistId,
+    @Schema(description = "아티스트명", example = "NewJeans")
+    String artist,
+    @Schema(description = "현재 페이지 번호", example = "0")
+    int currentPage,
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    boolean hasNext,
+    List<GroupBuyPotItem> pots
+) {
+    public static GroupBuyListResponse of(String postTitle, Long artistId, String artist, int currentPage, boolean hasNext, List<GroupBuyPotItem> pots) {
+        return GroupBuyListResponse.builder()
+                .postTitle(postTitle)
+                .artistId(artistId)
+                .artist(artist)
+                .currentPage(currentPage)
+                .hasNext(hasNext)
+                .pots(pots)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyPotItem.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyPotItem.java
@@ -1,0 +1,28 @@
+package org.sopt.poti.domain.groupbuy.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
+
+@Builder
+public record GroupBuyPotItem(
+    Long potId,
+    int price, // 최저가
+    String thumbnailUrl,
+    int currentCount,   // 현재 참여 인원
+    int totalCount,     // 최대 참여 가능 인원
+    GroupBuyPostStatus status,
+    List<String> availableMembers, // 남은 멤버 이름 리스트
+    UploaderInfo uploader
+) {
+
+  @Builder
+  public record UploaderInfo(
+      Long userId,
+      String nickname,
+      String profileImage,
+      double rating
+  ) {
+
+  }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyPotItem.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyPotItem.java
@@ -1,26 +1,39 @@
 package org.sopt.poti.domain.groupbuy.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
 
 @Builder
 public record GroupBuyPotItem(
+    @Schema(description = "분철 팟 게시글 ID", example = "101")
     Long potId,
+    @Schema(description = "1인당 가격 (최저가)", example = "21300")
     int price, // 최저가
+    @Schema(description = "썸네일 이미지 URL (없으면 null)", example = "https://s3.../101_thumb.jpg")
     String thumbnailUrl,
+    @Schema(description = "현재 참여 인원", example = "6")
     int currentCount,   // 현재 참여 인원
+    @Schema(description = "총 모집 인원", example = "7")
     int totalCount,     // 최대 참여 가능 인원
+    @Schema(description = "모집 상태", example = "RECRUITING")
     GroupBuyPostStatus status,
+    @Schema(description = "남은 멤버 이름 리스트", example = "[\"원영\", \"유진\"]")
     List<String> availableMembers, // 남은 멤버 이름 리스트
+    @Schema(description = "총대 정보")
     UploaderInfo uploader
 ) {
 
   @Builder
   public record UploaderInfo(
+      @Schema(description = "총대 유저 ID", example = "55")
       Long userId,
+      @Schema(description = "총대 닉네임", example = "분철의악마")
       String nickname,
+      @Schema(description = "총대 프로필 이미지 (없으면 null)", example = "https://s3.../55.jpg")
       String profileImage,
+      @Schema(description = "총대 평점", example = "4.8")
       double rating
   ) {
 

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryCustom.java
@@ -3,17 +3,21 @@ package org.sopt.poti.domain.groupbuy.repository;
 import java.util.List;
 import org.sopt.poti.domain.feed.dto.request.FeedSearchCondition;
 import org.sopt.poti.domain.feed.dto.response.FeedGroupItem;
+import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyListRequest;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
 import org.sopt.poti.domain.home.dto.response.HomeGroupBuyItem;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface GroupBuyRepositoryCustom {
 
-    List<String> findTitlesByKeyword(Long artistId, String keyword, int limit);
+  List<String> findTitlesByKeyword(Long artistId, String keyword, int limit);
 
-    List<HomeGroupBuyItem> findPopularTitlesByArtist(Long artistId, int limit);
+  List<HomeGroupBuyItem> findPopularTitlesByArtist(Long artistId, int limit);
 
-    List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long artistId, String sort, int limit);
+  List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long artistId, String sort, int limit);
 
-    Slice<FeedGroupItem> findFeedItems(FeedSearchCondition condition, Pageable pageable);
+  Slice<FeedGroupItem> findFeedItems(FeedSearchCondition condition, Pageable pageable);
+
+  Slice<GroupBuyPost> findGroupBuyList(GroupBuyListRequest request, Pageable pageable);
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
@@ -1,7 +1,10 @@
 package org.sopt.poti.domain.groupbuy.repository;
 
 import static org.sopt.poti.domain.artist.entity.QArtist.artist;
+import static org.sopt.poti.domain.groupbuy.entity.QGroupBuyOption.groupBuyOption;
 import static org.sopt.poti.domain.groupbuy.entity.QGroupBuyPost.groupBuyPost;
+import static org.sopt.poti.domain.groupbuy.entity.QItemImage.itemImage;
+import static org.sopt.poti.domain.order.entity.QOrderItem.orderItem;
 
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -16,8 +19,13 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.feed.dto.request.FeedSearchCondition;
 import org.sopt.poti.domain.feed.dto.response.FeedGroupItem;
+import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyListRequest;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
+import org.sopt.poti.domain.groupbuy.entity.QGroupBuyOption;
 import org.sopt.poti.domain.groupbuy.entity.QGroupBuyPost;
+import org.sopt.poti.domain.groupbuy.entity.QItemImage;
 import org.sopt.poti.domain.home.dto.response.HomeGroupBuyItem;
+import org.sopt.poti.domain.order.entity.QOrderItem;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -54,7 +62,7 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
                                         JPAExpressions.select(subGroupBuyPost.id.max())
                                                 .from(subGroupBuyPost)
                                                 .where(subGroupBuyPost.title.eq(groupBuyPost.title)
-                                                        .and(artistIdEq(artistId, subGroupBuyPost)) // artistId null 처리 적용
+                                                        .and(subGroupBuyPost.artist.id.eq(artistId))
                                                         .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
                                 )),
                         groupBuyPost.id.count(),
@@ -64,7 +72,7 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
                 ))
                 .from(groupBuyPost)
                 .join(groupBuyPost.artist, artist)
-                .where(artistIdEq(artistId, groupBuyPost)) // artistId null 처리 적용
+                .where(groupBuyPost.artist.id.eq(artistId))
                 .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
                 .orderBy(groupBuyPost.id.count().desc())
                 .limit(limit)
@@ -85,7 +93,7 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
                                         JPAExpressions.select(subGroupBuyPost.id.max())
                                                 .from(subGroupBuyPost)
                                                 .where(subGroupBuyPost.title.eq(groupBuyPost.title)
-                                                        .and(artistIdNe(artistId, subGroupBuyPost)) // artistId null 처리 적용
+                                                        .and(artistIdNe(artistId, subGroupBuyPost))
                                                         .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
                                 )),
                         groupBuyPost.id.count(),
@@ -95,9 +103,9 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
                 ))
                 .from(groupBuyPost)
                 .join(groupBuyPost.artist, artist)
-                .where(artistIdNe(artistId, groupBuyPost)) // artistId null 처리 적용
+                .where(artistIdNe(artistId, groupBuyPost))
                 .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
-                .orderBy(sortCondition(sort)) // 정렬 조건 적용
+                .orderBy(sortCondition(sort))
                 .limit(limit)
                 .fetch();
     }
@@ -119,7 +127,7 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
                                                         .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
                                 )),
                         groupBuyPost.title,
-                        groupBuyPost.id.count(), // postCount
+                        groupBuyPost.id.count(),
                         new CaseBuilder()
                                 .when(groupBuyPost.id.count().goe(5L)).then("인기")
                                 .otherwise("").as("tag")
@@ -142,6 +150,60 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
         return new SliceImpl<>(content, pageable, hasNext);
     }
 
+    @Override
+    public Slice<GroupBuyPost> findGroupBuyList(GroupBuyListRequest request, Pageable pageable) {
+        List<GroupBuyPost> content = queryFactory
+                .selectFrom(groupBuyPost)
+                .join(groupBuyPost.artist, artist).fetchJoin() // Artist Fetch Join
+                .join(groupBuyPost.leader).fetchJoin()         // Leader Fetch Join
+                .where(
+                        groupBuyPost.title.eq(request.title()),
+                        groupBuyPost.artist.id.eq(request.artistId()),
+                        memberIdsIn(request.memberIds()) // 멤버 필터링
+                )
+                .orderBy(listSortCondition(request.sort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = false;
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    // 멤버 필터링: 선택한 멤버들이 '남아있는(주문되지 않은)' 상태여야 함
+    private BooleanExpression memberIdsIn(List<Long> memberIds) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            return null;
+        }
+
+        // 서브쿼리: 이 게시글의 옵션 중에, memberId가 일치하면서, OrderItem이 없는(주문 안 된) 옵션이 존재하는가?
+        return JPAExpressions.selectOne()
+                .from(groupBuyOption)
+                .leftJoin(orderItem).on(orderItem.groupBuyOption.eq(groupBuyOption))
+                .where(
+                        groupBuyOption.groupBuyPost.eq(groupBuyPost),
+                        groupBuyOption.member.id.in(memberIds),
+                        orderItem.isNull() // 주문 내역이 없어야 함 (남은 멤버)
+                )
+                .exists();
+    }
+
+    private OrderSpecifier<?> listSortCondition(String sort) {
+        if ("DEADLINE".equalsIgnoreCase(sort)) {
+            return groupBuyPost.recruitDeadline.asc();
+        }
+        if ("RATING".equalsIgnoreCase(sort)) {
+            return groupBuyPost.leader.ratingAvg.desc();
+        }
+        // 기본값: 최신순
+        return groupBuyPost.createdAt.desc();
+    }
+
     private BooleanExpression artistIdNe(Long artistId, QGroupBuyPost post) {
         return artistId != null ? post.artist.id.ne(artistId) : null;
     }
@@ -159,7 +221,6 @@ public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
             int seed = Integer.parseInt(today.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
             return Expressions.numberTemplate(Double.class, "function('rand', {0})", seed).asc();
         }
-        // 기본값: 최신순
         return groupBuyPost.createdAt.max().desc();
     }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -12,12 +12,16 @@ import org.sopt.poti.domain.artist.service.MemberService;
 import org.sopt.poti.domain.delivery.entity.DeliveryMethod;
 import org.sopt.poti.domain.delivery.service.DeliveryService;
 import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyCreateRequest;
+import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyListRequest;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyCreateResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.ImageResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.ParticipantResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.ShippingResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.UploaderResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyListResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPotItem;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPotItem.UploaderInfo;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyOption;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
@@ -33,6 +37,7 @@ import org.sopt.poti.global.error.BusinessException;
 import org.sopt.poti.global.error.ErrorStatus;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -137,7 +142,7 @@ public class GroupBuyService {
     Integer reviewCount = reviewService.countReviewsForSeller(groupBuyPost.getLeader().getId());
     UploaderResponse uploaderResponse = UploaderResponse.builder()
         .userId(groupBuyPost.getLeader().getId())
-        .nickName(groupBuyPost.getLeader().getNickname())
+        .nickname(groupBuyPost.getLeader().getNickname())
         .profileImage(groupBuyPost.getLeader().getProfileImageUrl())
         .rating(groupBuyPost.getLeader().getRatingAvg())
         .reviewCount(reviewCount)
@@ -173,7 +178,7 @@ public class GroupBuyService {
 
             return ParticipantResponse.builder()
                 .userId(user.getId())
-                .nickName(user.getNickname())
+                .nickname(user.getNickname())
                 .profileImage(user.getProfileImageUrl())
                 .rating(user.getRatingAvg())
                 .selectedMembers(memberList)
@@ -208,6 +213,86 @@ public class GroupBuyService {
         .participants(participantResponseList)
         .price(minCost)
         .build();
+  }
+
+  /**
+   * 특정 상품에 해당하는 팟들을 조회합니다.
+   */
+  public GroupBuyListResponse getGroupBuyListByPostTitle(GroupBuyListRequest request,
+      Pageable pageable) {
+
+    Slice<GroupBuyPost> postsSlice = groupBuyRepository.findGroupBuyList(request, pageable);
+
+    List<GroupBuyPotItem> potItems = postsSlice.getContent().stream()
+        .map(post -> {
+          // 최저가 계산
+          int minPrice = post.getOptions().stream()
+              .mapToInt(GroupBuyOption::getPrice)
+              .min()
+              .orElse(0);
+
+          // 남은 멤버 리스트
+          List<String> availableMembers = calculateAvailableMembers(post.getOptions());
+
+          // 총대 정보
+          UploaderInfo uploaderInfo = UploaderInfo.builder()
+              .userId(post.getLeader().getId())
+              .nickname(post.getLeader().getNickname())
+              .profileImage(post.getLeader().getProfileImageUrl())
+              .rating(post.getLeader().getRatingAvg())
+              .build();
+
+          return GroupBuyPotItem.builder()
+              .potId(post.getId())
+              .price(minPrice)
+              .thumbnailUrl(post.getRepresentativeImageUrl())
+              .currentCount(post.getCurrentQuantity())
+              .totalCount(post.getGoalQuantity())
+              .status(post.getStatus())
+              .availableMembers(availableMembers)
+              .uploader(uploaderInfo)
+              .build();
+        })
+        .toList();
+
+    String postTitle = null; // itemName 대신 postTitle
+    String artistName = null;
+    Long artistId = null; // artistId 추가
+    if (!postsSlice.getContent().isEmpty()) {
+      GroupBuyPost firstPost = postsSlice.getContent().get(0);
+      postTitle = firstPost.getTitle();
+      artistId = firstPost.getArtist().getId(); // artistId 추가
+      artistName = firstPost.getArtist().getName();
+    }
+
+    return GroupBuyListResponse.of(
+        postTitle,
+        artistId,
+        artistName,
+        postsSlice.getNumber(), // 현재 페이지 번호
+        postsSlice.hasNext(),
+        potItems
+    );
+  }
+
+  // 남은 멤버 리스트 계산 헬퍼 메서드 (기존 calculateAvailableMembers 재사용)
+  private List<String> calculateAvailableMembers(List<GroupBuyOption> options) {
+    if (options.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<Long> optionIds = options.stream().map(GroupBuyOption::getId).toList();
+
+    List<OrderItem> orderedItems = orderService.getOrderItemsByOptionIds(optionIds);
+
+    List<Long> soldOptionIds = orderedItems.stream()
+        .map(item -> item.getGroupBuyOption().getId())
+        .distinct()
+        .toList();
+
+    return options.stream()
+        .filter(option -> !soldOptionIds.contains(option.getId()))
+        .map(option -> option.getMember().getName())
+        .toList();
   }
 
   public int countByLeader_Id(Long userId) {

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -3,6 +3,7 @@ package org.sopt.poti.domain.groupbuy.service;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.artist.entity.Artist;
@@ -21,7 +22,6 @@ import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.Shippin
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.UploaderResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyListResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPotItem;
-import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPotItem.UploaderInfo;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyOption;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
@@ -35,7 +35,6 @@ import org.sopt.poti.domain.user.entity.User;
 import org.sopt.poti.domain.user.service.UserService;
 import org.sopt.poti.global.error.BusinessException;
 import org.sopt.poti.global.error.ErrorStatus;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -101,12 +100,11 @@ public class GroupBuyService {
   }
 
   public List<String> searchTitles(Long artistId, String keyword) {
-    Pageable pageable = PageRequest.of(0, 5);
+    Pageable pageable = org.springframework.data.domain.PageRequest.of(0, 5);
     return groupBuyRepository.findTitlesByKeyword(artistId, keyword, pageable.getPageSize());
   }
 
   public GroupBuyDetailResponse getGroupBuyDetail(Long userId, Long groupBuyId) {
-    // 2번의 추가 쿼리를 방지하기 위한 조회
     GroupBuyPost groupBuyPost = groupBuyRepository.findByIdWithUserAndArtist(groupBuyId)
         .orElseThrow(() -> new BusinessException(ErrorStatus.POST_NOT_FOUND));
 
@@ -151,40 +149,37 @@ public class GroupBuyService {
     /**
      * 참여자 리스트
      */
-    // 구매한 order 참여자들 리스트
     List<GroupBuyOption> options = groupBuyPost.getOptions();
     List<Long> optionIds = options.stream().map(GroupBuyOption::getId).toList();
 
     List<ParticipantResponse> participantResponseList = Collections.emptyList();
 
-    // 이 분철글에 옵션이 하나라도 있어야 주문이 가능
     if (!optionIds.isEmpty()) {
-      List<OrderItem> orderItemsByOrderId = orderService.getOrderItemsByOptionIds(optionIds);
+      List<OrderItem> orderItems = orderService.getOrderItemsByOptionIds(optionIds);
 
-      // 참여자 기준으로 OrderItem 묶기
-      Map<User, List<OrderItem>> itemsByUser = orderItemsByOrderId.stream()
-          .collect(Collectors.groupingBy(item -> item.getOrder().getUser()));
+      if (!orderItems.isEmpty()) {
+        Map<User, List<OrderItem>> itemsByUser = orderItems.stream()
+            .collect(Collectors.groupingBy(item -> item.getOrder().getUser()));
 
-      // 참여자 리스트 반환
-      participantResponseList = itemsByUser.entrySet().stream()
-          .map(entry -> {
-            User user = entry.getKey();
-            List<OrderItem> items = entry.getValue();
+        participantResponseList = itemsByUser.entrySet().stream()
+            .map(entry -> {
+              User user = entry.getKey();
+              List<OrderItem> items = entry.getValue();
 
-            // 해당 유저가 선택한 멤버옵션 이름 추출
-            List<String> memberList = items.stream()
-                .map(item -> item.getGroupBuyOption().getMember().getName())
-                .toList();
+              List<String> memberList = items.stream()
+                  .map(item -> item.getGroupBuyOption().getMember().getName())
+                  .toList();
 
-            return ParticipantResponse.builder()
-                .userId(user.getId())
-                .nickname(user.getNickname())
-                .profileImage(user.getProfileImageUrl())
-                .rating(user.getRatingAvg())
-                .selectedMembers(memberList)
-                .build();
-          })
-          .toList();
+              return ParticipantResponse.builder()
+                  .userId(user.getId())
+                  .nickname(user.getNickname())
+                  .profileImage(user.getProfileImageUrl())
+                  .rating(user.getRatingAvg())
+                  .selectedMembers(memberList)
+                  .build();
+            })
+            .toList();
+      }
     }
 
     /**
@@ -220,22 +215,38 @@ public class GroupBuyService {
    */
   public GroupBuyListResponse getGroupBuyListByPostTitle(GroupBuyListRequest request,
       Pageable pageable) {
-
     Slice<GroupBuyPost> postsSlice = groupBuyRepository.findGroupBuyList(request, pageable);
+
+    // 1. 모든 게시글의 옵션 ID 수집
+    List<Long> allOptionIds = postsSlice.getContent().stream()
+        .flatMap(post -> post.getOptions().stream())
+        .map(GroupBuyOption::getId)
+        .toList();
+
+    // 2. 한 번의 쿼리로 모든 주문 내역 조회 (판매된 옵션 확인)
+    List<OrderItem> allOrderItems = allOptionIds.isEmpty()
+        ? Collections.emptyList()
+        : orderService.getOrderItemsByOptionIds(allOptionIds);
+
+    // 3. 판매된 옵션 ID Set 생성
+    Set<Long> soldOptionIds = allOrderItems.stream()
+        .map(item -> item.getGroupBuyOption().getId())
+        .collect(Collectors.toSet());
 
     List<GroupBuyPotItem> potItems = postsSlice.getContent().stream()
         .map(post -> {
-          // 최저가 계산
           int minPrice = post.getOptions().stream()
               .mapToInt(GroupBuyOption::getPrice)
               .min()
               .orElse(0);
 
           // 남은 멤버 리스트
-          List<String> availableMembers = calculateAvailableMembers(post.getOptions());
+          List<String> availableMembers = post.getOptions().stream()
+              .filter(option -> !soldOptionIds.contains(option.getId()))
+              .map(option -> option.getMember().getName())
+              .toList();
 
-          // 총대 정보
-          UploaderInfo uploaderInfo = UploaderInfo.builder()
+          GroupBuyPotItem.UploaderInfo uploaderInfo = GroupBuyPotItem.UploaderInfo.builder()
               .userId(post.getLeader().getId())
               .nickname(post.getLeader().getNickname())
               .profileImage(post.getLeader().getProfileImageUrl())
@@ -255,13 +266,13 @@ public class GroupBuyService {
         })
         .toList();
 
-    String postTitle = null; // itemName 대신 postTitle
+    String postTitle = null;
     String artistName = null;
-    Long artistId = null; // artistId 추가
+    Long artistId = null;
     if (!postsSlice.getContent().isEmpty()) {
       GroupBuyPost firstPost = postsSlice.getContent().get(0);
       postTitle = firstPost.getTitle();
-      artistId = firstPost.getArtist().getId(); // artistId 추가
+      artistId = firstPost.getArtist().getId();
       artistName = firstPost.getArtist().getName();
     }
 
@@ -273,26 +284,6 @@ public class GroupBuyService {
         postsSlice.hasNext(),
         potItems
     );
-  }
-
-  // 남은 멤버 리스트 계산 헬퍼 메서드 (기존 calculateAvailableMembers 재사용)
-  private List<String> calculateAvailableMembers(List<GroupBuyOption> options) {
-    if (options.isEmpty()) {
-      return Collections.emptyList();
-    }
-    List<Long> optionIds = options.stream().map(GroupBuyOption::getId).toList();
-
-    List<OrderItem> orderedItems = orderService.getOrderItemsByOptionIds(optionIds);
-
-    List<Long> soldOptionIds = orderedItems.stream()
-        .map(item -> item.getGroupBuyOption().getId())
-        .distinct()
-        .toList();
-
-    return options.stream()
-        .filter(option -> !soldOptionIds.contains(option.getId()))
-        .map(option -> option.getMember().getName())
-        .toList();
   }
 
   public int countByLeader_Id(Long userId) {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #56 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

  1. 상품별 분철 팟 목록 조회 API 구현 (GET /api/v1/groupbuys/pots)
   - 특정 아티스트의 특정 상품명에 해당하는 분철 팟(게시글) 목록을 조회하는 API를 구현했습니다.
   - 필터링: postTitle, artistId, memberIds (남아있는 멤버 필터)
   - 정렬: LATEST, DEADLINE, RATING (평점순, 마감임박순, 최신순)
   - 페이징: Pageable 파라미터를 통해 페이지네이션을 지원하며, GroupBuyListResponse에 currentPage, hasNext 정보를 포함합니다.

  2. DTO 및 Repository 로직 개선
   - GroupBuyListRequest DTO에 title, artistId, sort, memberIds 필드를 정의했습니다. title 필드는 앞뒤 공백 제거 로직을 Compact Constructor에 추가했습니다.
   - GroupBuyListResponse DTO에 postTitle, artistId, artist, currentPage, hasNext, pots 필드를 정의하여 명세에 맞췄습니다. totalCount 필드는 제거했습니다.
   - GroupBuyRepositoryCustom 및 GroupBuyRepositoryImpl에 findGroupBuyList 메서드를 추가하여 복잡한 필터링(남아있는 멤버) 및 정렬 로직을 QueryDSL로 구현했습니다.


## 📸 테스트 증명 (필수) 
- 필터링 조건 
<img width="1880" height="1508" alt="image" src="https://github.com/user-attachments/assets/68887a04-a41a-480d-9539-f0036f020fee" />

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
   - `@ModelAttribute`: 쿼리 파라미터를 DTO로 받기 위해 GroupBuyListRequest에 Pageable 필드를 제거하고 컨트롤러에서 @ModelAttribute와 @PageableDefault를 함께 사용했습니다.
   - 남아있는 멤버 필터링: GroupBuyRepositoryImpl의 memberIdsIn 메서드에서 GroupBuyOption과 OrderItem 조인으로 미판매된 옵션을 가진 게시글을 필터링합니다.
   - 근데 마감일자, 최신순과 같은 기준이 있다면 해당 내용들도 보여줘야 하는거 아닌가 싶긴 하네요..? 기획에 질문 해봐야 할 것 같습니다.


## ✅ 체크리스트
   - [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
   - [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
   - [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
   - [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 그룹구매 게시글 목록 조회 기능 추가: 아티스트·상품명 필터와 페이지네이션을 지원합니다.
  * 목록에서 각 상품의 가격, 참여 현황(현재/총), 진행 상태, 판매자(업로더) 정보 및 썸네일을 확인할 수 있습니다.

* **Bug Fixes / Changes**
  * 일부 응답 필드명(nickName → nickname)이 변경되어 일관된 표시가 제공됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->