### PR TITLE
[FEAT] 분철 참여용 옵션 조회 API 구현 및 Swagger 문서화

### DIFF
--- a/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
@@ -11,6 +11,7 @@ import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyListRequest;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyCreateResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyListResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyTitlesResponse;
 import org.sopt.poti.domain.groupbuy.service.GroupBuyService;
 import org.sopt.poti.global.common.ApiResponse;
@@ -90,5 +91,15 @@ public class GroupBuyController {
     return ResponseEntity.ok(
         ApiResponse.success(SuccessStatus.OK, response)
     );
+  }
+
+  @GetMapping("/{postId}/options")
+  @Operation(summary = "분철글 선택 가능한 분철 멤버 옵션과 배송 방법 조회", description = "특정 분철글에 참여(구매) 가능한 멤버 옵션과 배송 방법들을 조회합니다.")
+  public ResponseEntity<ApiResponse<GroupBuyPostOptionResponse>> getGroupBuyOptionList(
+      @PathVariable(name = "postId") Long postId
+  ) {
+    GroupBuyPostOptionResponse groupBuyPostOptionResponse = groupBuyService.getGroupBuyPostOptionResponse(
+        postId);
+    return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, groupBuyPostOptionResponse));
   }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyPostOptionResponse.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyPostOptionResponse.java
@@ -1,0 +1,34 @@
+package org.sopt.poti.domain.groupbuy.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record GroupBuyPostOptionResponse(
+    @Schema(description = "선택 가능한 멤버 옵션 리스트")
+    List<GroupBuyPostMemberOption> members,
+    @Schema(description = "선택 가능한 배송 옵션 리스트")
+    List<GroupBuyPostDeliveryOption> options
+) {
+
+  public record GroupBuyPostMemberOption(
+      @Schema(description = "멤버 옵션 ID (주문 시 사용)", example = "1")
+      Long memberId,
+      @Schema(description = "멤버 이름", example = "하니")
+      String memberName,
+      @Schema(description = "옵션 가격", example = "15000")
+      Integer memberPrice
+  ) {
+
+  }
+
+  public record GroupBuyPostDeliveryOption(
+      @Schema(description = "배송 옵션 ID (주문 시 사용)", example = "10")
+      Long deliveryOptionId,
+      @Schema(description = "배송 방법명", example = "일반 택배")
+      String deliveryName,
+      @Schema(description = "배송비", example = "3000")
+      Integer deliveryOptionPrice
+  ) {
+
+  }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyShipping.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyShipping.java
@@ -13,7 +13,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.sopt.poti.domain.delivery.entity.DeliveryMethod;
+import org.sopt.poti.domain.order.entity.Order;
 
 @Getter
 @Entity
@@ -21,37 +23,44 @@ import org.sopt.poti.domain.delivery.entity.DeliveryMethod;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupBuyShipping {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Column(nullable = false)
-    private int price; // 해당 공구에서의 배송비
+  @Column(nullable = false)
+  private int price; // 해당 공구에서의 배송비
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_buy_post_id", nullable = false)
-    private GroupBuyPost groupBuyPost;
+  // 양방향 연관관계 편의 메서드
+  @Setter
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "group_buy_post_id", nullable = false)
+  private GroupBuyPost groupBuyPost;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "delivery_method_id", nullable = false)
-    private DeliveryMethod deliveryMethod;
+  @Setter
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "delivery_method_id", nullable = false)
+  private DeliveryMethod deliveryMethod;
 
-    @Builder
-    private GroupBuyShipping(int price, GroupBuyPost groupBuyPost, DeliveryMethod deliveryMethod) {
-        this.price = price;
-        this.groupBuyPost = groupBuyPost;
-        this.deliveryMethod = deliveryMethod;
-    }
+  @Setter
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "order_id")
+  private Order order;
 
-    public static GroupBuyShipping create(int price, DeliveryMethod deliveryMethod) {
-        return GroupBuyShipping.builder()
-                .price(price)
-                .deliveryMethod(deliveryMethod)
-                .build();
-    }
+  @Builder
+  private GroupBuyShipping(int price, GroupBuyPost groupBuyPost, DeliveryMethod deliveryMethod,
+      Order order) {
+    this.price = price;
+    this.groupBuyPost = groupBuyPost;
+    this.deliveryMethod = deliveryMethod;
+    this.order = order;
+  }
 
-    // 양방향 연관관계 편의 메서드
-    public void setGroupBuyPost(GroupBuyPost groupBuyPost) {
-        this.groupBuyPost = groupBuyPost;
-    }
+  public static GroupBuyShipping create(int price, DeliveryMethod deliveryMethod, Order order) {
+    return GroupBuyShipping.builder()
+        .price(price)
+        .deliveryMethod(deliveryMethod)
+        .order(order)
+        .build();
+  }
+
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -300,7 +300,10 @@ public class GroupBuyService {
     List<Long> optionIds = options.stream().map(GroupBuyOption::getId).toList();
 
     // 이미 주문된(팔린) 옵션 조회 (OrderItem이 존재하는 옵션)
-    List<OrderItem> soldItems = orderService.getOrderItemsByOptionIds(optionIds);
+    List<OrderItem> soldItems = optionIds.isEmpty()
+        ? Collections.emptyList()
+        : orderService.getOrderItemsByOptionIds(optionIds);
+    
     Set<Long> soldOptionIds = soldItems.stream()
         .map(item -> item.getGroupBuyOption().getId())
         .collect(Collectors.toSet());

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -21,6 +21,9 @@ import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.Partici
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.ShippingResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.UploaderResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyListResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse.GroupBuyPostDeliveryOption;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse.GroupBuyPostMemberOption;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPotItem;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyOption;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
@@ -84,7 +87,8 @@ public class GroupBuyService {
     request.shippings().forEach(shippingRequest -> {
       DeliveryMethod deliveryMethod = deliveryService.getDeliveryMethodById(
           shippingRequest.deliveryMethodId());
-      GroupBuyShipping shipping = GroupBuyShipping.create(shippingRequest.price(), deliveryMethod);
+      GroupBuyShipping shipping = GroupBuyShipping.create(shippingRequest.price(), deliveryMethod,
+          null);
       groupBuyPost.addShipping(shipping);
     });
 
@@ -284,6 +288,47 @@ public class GroupBuyService {
         postsSlice.hasNext(),
         potItems
     );
+  }
+
+  public GroupBuyPostOptionResponse getGroupBuyPostOptionResponse(Long postId) {
+    // 게시글 및 옵션 전체 조회
+    GroupBuyPost post = groupBuyRepository.findById(postId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.POST_NOT_FOUND));
+    List<GroupBuyOption> options = post.getOptions();
+
+    // option 식별자들 추출
+    List<Long> optionIds = options.stream().map(GroupBuyOption::getId).toList();
+
+    // 이미 주문된(팔린) 옵션 조회 (OrderItem이 존재하는 옵션)
+    List<OrderItem> soldItems = orderService.getOrderItemsByOptionIds(optionIds);
+    Set<Long> soldOptionIds = soldItems.stream()
+        .map(item -> item.getGroupBuyOption().getId())
+        .collect(Collectors.toSet());
+
+    // 이미 팔린 옵션 제외
+    List<GroupBuyOption> memberList = options.stream()
+        .filter(option -> !soldOptionIds.contains(option.getId()))
+        .toList();
+
+    List<GroupBuyPostMemberOption> groupBuyPostMemberOptions = memberList.stream().map(
+            member ->
+                new GroupBuyPostMemberOption(
+                    member.getId(),
+                    member.getMember().getName(),
+                    member.getPrice())
+        )
+        .toList();
+
+    List<GroupBuyPostDeliveryOption> deliveryOptions = post.getShippings().stream().map(
+            delivery ->
+                new GroupBuyPostDeliveryOption(
+                    delivery.getId(),
+                    delivery.getDeliveryMethod().getName(),
+                    delivery.getPrice())
+        )
+        .toList();
+
+    return new GroupBuyPostOptionResponse(groupBuyPostMemberOptions, deliveryOptions);
   }
 
   public int countByLeader_Id(Long userId) {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #60 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
  1. 분철 참여용 옵션 조회 API 구현 (GET /api/v1/posts/{postId}/options)
   - 특정 분철글(게시글)에서 구매 가능한(남아있는) 멤버 옵션과 선택 가능한 배송 옵션 목록을 조회하는 API를 구현했습니다.
   - 주요 로직:
       - GroupBuyService에서 해당 게시글의 전체 옵션 중 OrderItem과 연결되지 않은(미판매) 옵션만 필터링하여 반환합니다.
       - 배송 옵션은 게시글에 설정된 모든 배송 방법을 반환합니다.
   - DTO: GroupBuyPostOptionResponse를 사용하여 멤버 옵션(members)과 배송 옵션(options)을 구조화하여 전달합니다.

  2. Swagger 문서화 보강
   - GroupBuyPostOptionResponse 및 내부 레코드(GroupBuyPostMemberOption, GroupBuyPostDeliveryOption)에 @Schema 어노테이션을 추가하여 API 명세를 명확히 했습니다.
   - 각 필드(memberId, price, deliveryOptionId 등)에 대한 설명과 예시 값을 제공합니다.

  3. 기타
   - DevController에 유저 완전 삭제(DELETE /dev/users/me) 기능을 추가하여 개발 편의성을 높였습니다. (이전 커밋 내용 포함 시)
   
## 📸 테스트 증명 (필수) 
<img width="928" height="1376" alt="image" src="https://github.com/user-attachments/assets/b3665067-db71-4c3b-ab0d-a137a2cbf75e" />

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
   - 옵션 필터링: orderService.getOrderItemsByOptionIds를 통해 판매된 옵션을 조회하고, 전체 옵션에서 이를 제외하는 방식으로 availableMembers를 계산했습니다.
   - 필드명: 클라이언트 요청에 맞춰 memberPrice, deliveryOptionPrice 등으로 명확하게 네이밍했습니다.

## ✅ 체크리스트
   - [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
   - [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
   - [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
   - [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 특정 게시물의 그룹 구매 옵션과 배송 방법을 조회하는 새 API 추가
  * 이미 판매된 옵션을 제외하고 사용 가능한 옵션만 반환하도록 필터링 적용
  * 응답에 참여자별 옵션 정보와 배송옵션 목록을 포함하여 선택 가능한 항목을 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->