### PR TITLE
[FEAT] 모집자(총대)가 참여자의 입금 상태를 입금 완료로 변경하는 API 구현

### DIFF
--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
@@ -14,11 +14,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,29 +28,29 @@ import org.sopt.poti.global.entity.BaseTimeEntity;
 @Getter
 @Entity
 @Table(name = "group_buy_posts", indexes = { // 인덱스 추가
-        @Index(name = "idx_group_buy_post_title", columnList = "title")
+    @Index(name = "idx_group_buy_post_title", columnList = "title")
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupBuyPost extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Column(nullable = false, length = 200)
-    private String title;
+  @Column(nullable = false, length = 200)
+  private String title;
 
-    @Column(columnDefinition = "TEXT")
-    private String content;
+  @Column(columnDefinition = "TEXT")
+  private String content;
 
-    @Column(name = "recruit_deadline", nullable = false) // 마감일 필수
-    private LocalDate recruitDeadline;
+  @Column(name = "recruit_deadline", nullable = false) // 마감일 필수
+  private LocalDate recruitDeadline;
 
-    @Column(name = "bank_name", length = 50, nullable = false) // 은행명 필수
-    private String bankName;
+  @Column(name = "bank_name", length = 50, nullable = false) // 은행명 필수
+  private String bankName;
 
-    @Column(name = "account_number", length = 50, nullable = false) // 계좌번호 필수
-    private String accountNumber;
+  @Column(name = "account_number", length = 50, nullable = false) // 계좌번호 필수
+  private String accountNumber;
 
   @Column(name = "representative_image_url") // 대표 이미지 URL (성능 최적화용)
   private String representativeImageUrl;
@@ -139,13 +137,18 @@ public class GroupBuyPost extends BaseTimeEntity {
     option.setGroupBuyPost(this); // 양방향 연관관계 설정
   }
 
-    public void addImage(ItemImage image) {
-        this.images.add(image);
-        image.setGroupBuyPost(this); // 양방향 연관관계 설정
-    }
+  public void addImage(ItemImage image) {
+    this.images.add(image);
+    image.setGroupBuyPost(this); // 양방향 연관관계 설정
+  }
 
-    public void addShipping(GroupBuyShipping shipping) {
-        this.shippings.add(shipping);
-        shipping.setGroupBuyPost(this); // 양방향 연관관계 설정
-    }
+  public void addShipping(GroupBuyShipping shipping) {
+    this.shippings.add(shipping);
+    shipping.setGroupBuyPost(this); // 양방향 연관관계 설정
+  }
+
+  // 분철글 상태 변경 메서드
+  public void updateStatus(GroupBuyPostStatus status) {
+    this.status = status;
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/sopt/poti/domain/order/repository/OrderRepository.java
@@ -6,17 +6,23 @@ import org.sopt.poti.domain.order.entity.OrderStatus;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    int countByUser_Id(Long userId);
+  int countByUser_Id(Long userId);
 
-    int countByUser_IdAndStatusIn(Long userId, List<OrderStatus> statuses);
+  int countByUser_IdAndStatusIn(Long userId, List<OrderStatus> statuses);
 
-    @EntityGraph(attributePaths = {
-            "groupBuyPost",
-            "groupBuyPost.artist"
-    })
-    List<Order> findByUser_IdOrderByCreatedAtDesc(Long userId);
+  @EntityGraph(attributePaths = {
+      "groupBuyPost",
+      "groupBuyPost.artist"
+  })
+  List<Order> findByUser_IdOrderByCreatedAtDesc(Long userId);
 
-    void deleteByUser_Id(Long userId);
+  void deleteByUser_Id(Long userId);
+
+  @Query("SELECT COUNT(o) FROM Order o WHERE o.groupBuyPost.id = :postId AND o.status <> :status")
+  long countUnpaidOrders(@Param("postId") Long postId, @Param("status") OrderStatus status);
 }

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
@@ -1,5 +1,6 @@
 package org.sopt.poti.domain.order.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.order.entity.Order;
 import org.sopt.poti.domain.order.entity.OrderItem;
@@ -10,8 +11,6 @@ import org.sopt.poti.global.error.BusinessException;
 import org.sopt.poti.global.error.ErrorStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -51,7 +50,12 @@ public class OrderService {
   }
 
 
-    public List<Order> getOrdersByUser(Long userId) {
-        return orderRepository.findByUser_IdOrderByCreatedAtDesc(userId);
-    }
+  public List<Order> getOrdersByUser(Long userId) {
+    return orderRepository.findByUser_IdOrderByCreatedAtDesc(userId);
+  }
+
+  // 해당 분철글에 대해 OrderStatus가 아닌 주문이 남아있는지 확인
+  public long countByGroupBuyPostIdAndStatusNot(Long postId, OrderStatus status) {
+    return orderRepository.countUnpaidOrders(postId, status);
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/payment/controller/PaymentController.java
+++ b/src/main/java/org/sopt/poti/domain/payment/controller/PaymentController.java
@@ -1,5 +1,6 @@
 package org.sopt.poti.domain.payment.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.payment.dto.request.DepositFormRequest;
@@ -36,6 +37,9 @@ public class PaymentController {
   }
 
   @PatchMapping("/{orderId}/confirm")
+  @Operation(summary = "모집자(총대)가 참여자의 입금 상태를 입금 완료로 변경", description =
+      "모집자가 참여자의 입금 상태를 입금 완료로 변경합니다."
+          + "\n 상태 변경시 해당 분철글에 대한 모든 주문들의 상태를 조회해 전부 입금 완료 상태(PAID)이면 분철글의 상태도 입금 완료 상태로 변경합니다.")
   public ResponseEntity<ApiResponse<OrderConfirmResponse>> confirmPayment(
       @AuthenticationPrincipal UserPrincipal userPrincipal,
       @PathVariable(name = "orderId") Long orderId

--- a/src/main/java/org/sopt/poti/domain/payment/controller/PaymentController.java
+++ b/src/main/java/org/sopt/poti/domain/payment/controller/PaymentController.java
@@ -4,12 +4,15 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.payment.dto.request.DepositFormRequest;
 import org.sopt.poti.domain.payment.dto.response.DepositFormResponse;
+import org.sopt.poti.domain.payment.dto.response.OrderConfirmResponse;
 import org.sopt.poti.domain.payment.service.PaymentService;
 import org.sopt.poti.global.common.ApiResponse;
 import org.sopt.poti.global.common.SuccessStatus;
 import org.sopt.poti.global.security.UserPrincipal;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,16 +22,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/payments")
 public class PaymentController {
-    private final PaymentService paymentService;
 
-    @PostMapping
-    public ResponseEntity<ApiResponse<DepositFormResponse>> submitDepositForm(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @RequestBody @Valid DepositFormRequest request
-    ) {
-        Long userId = userPrincipal.getUserId();
-        DepositFormResponse data = paymentService.submitDepositForm(userId, request);
-        return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, data));
-    }
+  private final PaymentService paymentService;
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<DepositFormResponse>> submitDepositForm(
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
+      @RequestBody @Valid DepositFormRequest request
+  ) {
+    Long userId = userPrincipal.getUserId();
+    DepositFormResponse data = paymentService.submitDepositForm(userId, request);
+    return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, data));
+  }
+
+  @PatchMapping("/{orderId}/confirm")
+  public ResponseEntity<ApiResponse<OrderConfirmResponse>> confirmPayment(
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
+      @PathVariable(name = "orderId") Long orderId
+  ) {
+    OrderConfirmResponse orderConfirmResponse = paymentService.confirmPayment(
+        userPrincipal.getUserId(), orderId);
+    return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, orderConfirmResponse));
+  }
 
 }

--- a/src/main/java/org/sopt/poti/domain/payment/dto/response/OrderConfirmResponse.java
+++ b/src/main/java/org/sopt/poti/domain/payment/dto/response/OrderConfirmResponse.java
@@ -1,0 +1,12 @@
+package org.sopt.poti.domain.payment.dto.response;
+
+import java.time.LocalDateTime;
+import org.sopt.poti.domain.order.entity.OrderStatus;
+
+public record OrderConfirmResponse(
+    Long orderId,
+    OrderStatus status,
+    LocalDateTime confirmedAt
+) {
+
+}

--- a/src/main/java/org/sopt/poti/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/sopt/poti/domain/payment/service/PaymentService.java
@@ -64,7 +64,7 @@ public class PaymentService {
         OrderStatus.PAID);
 
     //  미입금 주문이 없다면(모두 PAID라면) 분철글 상태 변경
-    if (allOrderPaid > 0) {
+    if (!(allOrderPaid > 0)) {
       groupBuyPost.updateStatus(GroupBuyPostStatus.PAYMENT_DONE);
     }
 

--- a/src/main/java/org/sopt/poti/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/sopt/poti/domain/payment/service/PaymentService.java
@@ -1,11 +1,15 @@
 package org.sopt.poti.domain.payment.service;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
 import org.sopt.poti.domain.order.entity.Order;
 import org.sopt.poti.domain.order.entity.OrderStatus;
 import org.sopt.poti.domain.order.service.OrderService;
 import org.sopt.poti.domain.payment.dto.request.DepositFormRequest;
 import org.sopt.poti.domain.payment.dto.response.DepositFormResponse;
+import org.sopt.poti.domain.payment.dto.response.OrderConfirmResponse;
 import org.sopt.poti.domain.payment.entity.Payment;
 import org.sopt.poti.domain.payment.repository.PaymentRepository;
 import org.sopt.poti.global.error.BusinessException;
@@ -15,27 +19,55 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class PaymentService {
 
-    private final PaymentRepository paymentRepository;
-    private final OrderService orderService;
+  private final PaymentRepository paymentRepository;
+  private final OrderService orderService;
 
-    public DepositFormResponse submitDepositForm(Long userId, DepositFormRequest req) {
-        Order order = orderService.getOrderById(req.orderId());
+  @Transactional
+  public DepositFormResponse submitDepositForm(Long userId, DepositFormRequest req) {
+    Order order = orderService.getOrderById(req.orderId());
 
-        orderService.validateOrderOwner(order, userId);
+    orderService.validateOrderOwner(order, userId);
 
-        if (order.getStatus() != OrderStatus.WAIT_PAY) {
-            throw new BusinessException(ErrorStatus.ORDER_NOT_WAIT_PAY);
-        }
-
-        Payment payment = paymentRepository.findTopByOrderIdOrderByIdDesc(order.getId())
-                .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
-
-        payment.submitDepositForm(req.depositorName(), req.depositedAt());
-        order.requestPayCheck();
-
-        return new DepositFormResponse(payment.getId());
+    if (order.getStatus() != OrderStatus.WAIT_PAY) {
+      throw new BusinessException(ErrorStatus.ORDER_NOT_WAIT_PAY);
     }
+
+    Payment payment = paymentRepository.findTopByOrderIdOrderByIdDesc(order.getId())
+        .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
+
+    payment.submitDepositForm(req.depositorName(), req.depositedAt());
+    order.requestPayCheck();
+
+    return new DepositFormResponse(payment.getId());
+  }
+
+  @Transactional
+  public OrderConfirmResponse confirmPayment(Long userId, Long orderId) {
+    Order order = orderService.getOrderById(orderId);
+    GroupBuyPost groupBuyPost = order.getGroupBuyPost();
+
+    // 분철글이 본인이 작성한 글인지 확인
+    if (!groupBuyPost.getLeader().getId().equals(userId)) {
+      throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
+    }
+
+    // 입금 확인됨으로 처리
+    order.confirmPayment();
+    OrderConfirmResponse orderConfirmResponse = new OrderConfirmResponse(orderId,
+        order.getStatus(), LocalDateTime.now());
+
+    // 해당 분철글에 대해 'PAID'가 아닌 주문이 남아있는지 확인
+    long allOrderPaid = orderService.countByGroupBuyPostIdAndStatusNot(groupBuyPost.getId(),
+        OrderStatus.PAID);
+
+    //  미입금 주문이 없다면(모두 PAID라면) 분철글 상태 변경
+    if (allOrderPaid > 0) {
+      groupBuyPost.updateStatus(GroupBuyPostStatus.PAYMENT_DONE);
+    }
+
+    return orderConfirmResponse;
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #62 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
  1. 입금 확인 처리 API 구현 (PATCH /api/v1/payments/{orderId})
   - 총대가 주문의 입금을 확인 처리하는 기능을 구현했습니다.
   - 주요 로직:
       - Order 상태를 PAID로 변경합니다.
       - 해당 분철글(GroupBuyPost)에 속한 모든 주문이 입금 완료(`PAID`)되었는지 확인합니다.
       - 모든 주문이 입금 완료되었다면, 분철글의 상태를 PAYMENT_DONE으로 자동 업데이트합니다.
   - 반환값: OrderConfirmResponse (주문ID, 변경된 상태, 처리 시간)

  2. Repository 및 Service 로직 개선
   - `OrderRepository`:
       - countUnpaidOrders 메서드를 JPQL로 구현하여, 특정 게시글에 대해 입금되지 않은 주문(status != PAID) 개수를 정확하게 카운트합니다. (NPE 방지 및 최적화)
   - `GroupBuyPost`:
       - @Version 필드(Optimistic Lock) 관련 데이터 정합성 문제를 해결하기 위해 더미 데이터 SQL 스크립트에 version 컬럼 초기화 값을 추가했습니다.

## 📸 테스트 증명 (필수) 
<img width="1042" height="1250" alt="image" src="https://github.com/user-attachments/assets/ef4985f0-2ce8-43da-91d1-1c492a0c8082" />


## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
   - `@Version` 필드: 낙관적 락(Optimistic Lock)을 위해 엔티티에 @Version 필드가 사용되고 있어서, 더미 데이터 생성 시 version = 0으로 초기화가 필요합니다.
   - 상태 동기화: 주문 상태 변경과 게시글 상태 변경이 하나의 트랜잭션(@Transactional) 안에서 원자적으로 수행됩니다.

## ✅ 체크리스트
   - [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
   - [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
   - [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
   - [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 결제 확인 API 추가: 참여자의 결제 상태를 개별적으로 확인/확정할 수 있습니다.
  * 결제 확정 응답에 확정 시각 포함.

* **개선 사항**
  * 모든 참여자의 결제가 완료되면 그룹 구매가 자동으로 "결제 완료"로 전환됩니다.
  * 주문 집계·조회 성능 및 배송 연동 처리 개선으로 상태 추적 정확도 향상.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->