### PR TITLE
[FEAT] 운송장 등록 API 구현 및 주문 조회 성능 최적화

### DIFF
--- a/src/main/java/org/sopt/poti/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/org/sopt/poti/domain/delivery/controller/DeliveryController.java
@@ -2,6 +2,7 @@ package org.sopt.poti.domain.delivery.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.delivery.dto.request.StartDeliveryRequest;
@@ -39,10 +40,10 @@ public class DeliveryController {
 
   @PatchMapping("/orders/{orderId}/deliveries")
   @Operation(summary = "주문에 해당하는 운송장 번호 등록", description = "주문에 해당하는 운송장 번호와 운송사를 등록할 수 있습니다.")
-  public ResponseEntity<ApiResponse<?>> startDelivery(
+  public ResponseEntity<ApiResponse<StartDeliveryResponse>> startDelivery(
       @AuthenticationPrincipal UserPrincipal userPrincipal,
       @PathVariable Long orderId,
-      @RequestBody StartDeliveryRequest startDeliveryRequest
+      @RequestBody @Valid StartDeliveryRequest startDeliveryRequest
   ) {
     StartDeliveryResponse startDeliveryResponse = orderService.startOrderDelivery(
         userPrincipal.getUserId(), orderId, startDeliveryRequest);

--- a/src/main/java/org/sopt/poti/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/org/sopt/poti/domain/delivery/controller/DeliveryController.java
@@ -4,27 +4,49 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.delivery.dto.request.StartDeliveryRequest;
 import org.sopt.poti.domain.delivery.dto.response.DeliveryOptionsResponse;
+import org.sopt.poti.domain.delivery.dto.response.StartDeliveryResponse;
 import org.sopt.poti.domain.delivery.service.DeliveryService;
+import org.sopt.poti.domain.order.service.OrderService;
 import org.sopt.poti.global.common.ApiResponse;
 import org.sopt.poti.global.common.SuccessStatus;
+import org.sopt.poti.global.security.UserPrincipal;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/deliveries")
+@RequestMapping("/api/v1")
 @Tag(name = "Delivery", description = "배송 관련 API")
 public class DeliveryController {
 
   private final DeliveryService deliveryService;
+  private final OrderService orderService;
 
-  @GetMapping
+  @GetMapping("/shippings")
   @Operation(summary = "배송 옵션 조회", description = "게시글 작성 시 선택 가능한 배송 방법 목록을 조회합니다.")
   public ResponseEntity<ApiResponse<List<DeliveryOptionsResponse>>> getDeliveryOptions() {
     List<DeliveryOptionsResponse> response = deliveryService.getDeliveryOptions();
     return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, response));
+  }
+
+  @PatchMapping("/orders/{orderId}/deliveries")
+  @Operation(summary = "주문에 해당하는 운송장 번호 등록", description = "주문에 해당하는 운송장 번호와 운송사를 등록할 수 있습니다.")
+  public ResponseEntity<ApiResponse<?>> startDelivery(
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
+      @PathVariable Long orderId,
+      @RequestBody StartDeliveryRequest startDeliveryRequest
+  ) {
+    StartDeliveryResponse startDeliveryResponse = orderService.startOrderDelivery(
+        userPrincipal.getUserId(), orderId, startDeliveryRequest);
+
+    return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, startDeliveryResponse));
   }
 }

--- a/src/main/java/org/sopt/poti/domain/delivery/dto/request/StartDeliveryRequest.java
+++ b/src/main/java/org/sopt/poti/domain/delivery/dto/request/StartDeliveryRequest.java
@@ -1,0 +1,8 @@
+package org.sopt.poti.domain.delivery.dto.request;
+
+public record StartDeliveryRequest(
+    String carrier,
+    String trackingNumber
+) {
+  
+}

--- a/src/main/java/org/sopt/poti/domain/delivery/dto/response/StartDeliveryResponse.java
+++ b/src/main/java/org/sopt/poti/domain/delivery/dto/response/StartDeliveryResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.poti.domain.delivery.dto.response;
+
+import java.time.LocalDateTime;
+import org.sopt.poti.domain.order.entity.OrderStatus;
+
+public record StartDeliveryResponse(
+    Long orderId,
+    OrderStatus status,
+    String trackingNumber,
+    LocalDateTime shippedAt
+) {
+
+}

--- a/src/main/java/org/sopt/poti/domain/delivery/entity/Delivery.java
+++ b/src/main/java/org/sopt/poti/domain/delivery/entity/Delivery.java
@@ -1,12 +1,20 @@
 package org.sopt.poti.domain.delivery.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.poti.domain.order.entity.Order;
-import org.sopt.poti.domain.order.entity.OrderStatus;
 
 @Getter
 @Entity
@@ -14,28 +22,31 @@ import org.sopt.poti.domain.order.entity.OrderStatus;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Delivery {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Column(name = "tracking_number", length = 50)
-    private String trackingNumber;
+  @Column(name = "tracking_number", length = 50)
+  private String trackingNumber;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private OrderStatus status;
+  @Column(nullable = false)
+  private String carrier; // 배송사
 
-    @Column(name = "shipped_at")
-    private LocalDateTime shippedAt;
+  @Column(name = "shipped_at")
+  private LocalDateTime shippedAt;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_id", nullable = false, unique = true)
-    private Order order;
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "order_id", nullable = false, unique = true)
+  private Order order;
 
-    public static Delivery create(Order order) {
-        Delivery d = new Delivery();
-        d.order = order;
-        d.status = OrderStatus.READY;
-        return d;
-    }
+  @Builder
+  public Delivery(String trackingNumber, String carrier,
+      LocalDateTime shippedAt,
+      Order order) {
+    this.trackingNumber = trackingNumber;
+    this.carrier = carrier;
+    this.shippedAt = shippedAt;
+    this.order = order;
+  }
+  
 }

--- a/src/main/java/org/sopt/poti/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/org/sopt/poti/domain/delivery/repository/DeliveryRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.poti.domain.delivery.repository;
+
+import org.sopt.poti.domain.delivery.entity.Delivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+
+}

--- a/src/main/java/org/sopt/poti/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/org/sopt/poti/domain/delivery/service/DeliveryService.java
@@ -3,8 +3,10 @@ package org.sopt.poti.domain.delivery.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.delivery.dto.response.DeliveryOptionsResponse;
+import org.sopt.poti.domain.delivery.entity.Delivery;
 import org.sopt.poti.domain.delivery.entity.DeliveryMethod;
 import org.sopt.poti.domain.delivery.repository.DeliveryMethodRepository;
+import org.sopt.poti.domain.delivery.repository.DeliveryRepository;
 import org.sopt.poti.global.error.BusinessException;
 import org.sopt.poti.global.error.ErrorStatus;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeliveryService {
 
   private final DeliveryMethodRepository deliveryMethodRepository;
+  private final DeliveryRepository deliveryRepository;
 
   public DeliveryMethod getDeliveryMethodById(Long deliveryMethodId) {
     return deliveryMethodRepository.findById(deliveryMethodId)
@@ -30,5 +33,10 @@ public class DeliveryService {
             deliveryMethod.getPrice()
         ))
         .toList();
+  }
+
+  @Transactional
+  public void saveDelivery(Delivery delivery) {
+    deliveryRepository.save(delivery);
   }
 }

--- a/src/main/java/org/sopt/poti/domain/order/entity/Order.java
+++ b/src/main/java/org/sopt/poti/domain/order/entity/Order.java
@@ -128,8 +128,11 @@ public class Order extends BaseTimeEntity {
     this.status = OrderStatus.PAID;
   }
 
-  // 주문 상태 변경 메서드
-  public void updateStatus(OrderStatus status) {
-    this.status = status;
+  // 주문 상태 배달 중으로 변경 메서드 (PAID 또는 READY 상태에서만 가능)
+  public void startDelivery() {
+    if (this.status == OrderStatus.PAID || this.status == OrderStatus.READY) {
+      this.status = OrderStatus.SHIPPED;
+    }
+    throw new BusinessException(ErrorStatus.ORDER_NOT_PAID_OR_READY);
   }
 }

--- a/src/main/java/org/sopt/poti/domain/order/entity/Order.java
+++ b/src/main/java/org/sopt/poti/domain/order/entity/Order.java
@@ -130,9 +130,9 @@ public class Order extends BaseTimeEntity {
 
   // 주문 상태 배달 중으로 변경 메서드 (PAID 또는 READY 상태에서만 가능)
   public void startDelivery() {
-    if (this.status == OrderStatus.PAID || this.status == OrderStatus.READY) {
-      this.status = OrderStatus.SHIPPED;
+    if (this.status != OrderStatus.PAID && this.status != OrderStatus.READY) {
+      throw new BusinessException(ErrorStatus.ORDER_NOT_PAID_OR_READY);
     }
-    throw new BusinessException(ErrorStatus.ORDER_NOT_PAID_OR_READY);
+    this.status = OrderStatus.SHIPPED;
   }
 }

--- a/src/main/java/org/sopt/poti/domain/order/entity/Order.java
+++ b/src/main/java/org/sopt/poti/domain/order/entity/Order.java
@@ -1,6 +1,21 @@
 package org.sopt.poti.domain.order.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -22,93 +37,99 @@ import org.sopt.poti.global.error.ErrorStatus;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Version
-    private Long version;
+  @Version
+  private Long version;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 30)
-    private OrderStatus status;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 30)
+  private OrderStatus status;
 
-    @Column(nullable = false)
-    private int totalAmount;
+  @Column(nullable = false)
+  private int totalAmount;
 
-    @Embedded
-    private DeliveryInfo deliveryInfo;
+  @Embedded
+  private DeliveryInfo deliveryInfo;
 
-    @Column(name = "request_info", columnDefinition = "TEXT")
-    private String requestInfo;
+  @Column(name = "request_info", columnDefinition = "TEXT")
+  private String requestInfo;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_buy_post_id", nullable = false)
-    private GroupBuyPost groupBuyPost;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "group_buy_post_id", nullable = false)
+  private GroupBuyPost groupBuyPost;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "delivery_method_id", nullable = false)
-    private DeliveryMethod deliveryMethod;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "delivery_method_id", nullable = false)
+  private DeliveryMethod deliveryMethod;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<OrderItem> orderItems = new ArrayList<>();
+  @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+  private final List<OrderItem> orderItems = new ArrayList<>();
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<Payment> payments = new ArrayList<>();
+  @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+  private final List<Payment> payments = new ArrayList<>();
 
-    @OneToOne(mappedBy = "order", fetch = FetchType.LAZY)
-    private Review review;
+  @OneToOne(mappedBy = "order", fetch = FetchType.LAZY)
+  private Review review;
 
-    @Builder
-    private Order(
-            GroupBuyPost groupBuyPost,
-            User user,
-            DeliveryMethod deliveryMethod,
-            int totalAmount,
-            DeliveryInfo deliveryInfo,
-            String requestInfo
-    ) {
-        this.groupBuyPost = groupBuyPost;
-        this.user = user;
-        this.deliveryMethod = deliveryMethod;
-        this.totalAmount = totalAmount;
-        this.deliveryInfo = deliveryInfo;
-        this.requestInfo = requestInfo;
-        this.status = OrderStatus.WAIT_PAY;
+  @Builder
+  private Order(
+      GroupBuyPost groupBuyPost,
+      User user,
+      DeliveryMethod deliveryMethod,
+      int totalAmount,
+      DeliveryInfo deliveryInfo,
+      String requestInfo
+  ) {
+    this.groupBuyPost = groupBuyPost;
+    this.user = user;
+    this.deliveryMethod = deliveryMethod;
+    this.totalAmount = totalAmount;
+    this.deliveryInfo = deliveryInfo;
+    this.requestInfo = requestInfo;
+    this.status = OrderStatus.WAIT_PAY;
+  }
+
+  public static Order create(
+      GroupBuyPost post,
+      User user,
+      DeliveryMethod method,
+      int totalAmount,
+      DeliveryInfo deliveryInfo,
+      String requestInfo
+  ) {
+    return Order.builder()
+        .groupBuyPost(post)
+        .user(user)
+        .deliveryMethod(method)
+        .totalAmount(totalAmount)
+        .deliveryInfo(deliveryInfo)
+        .requestInfo(requestInfo)
+        .build();
+  }
+
+  public void requestPayCheck() {
+    if (this.status != OrderStatus.WAIT_PAY) {
+      throw new BusinessException(ErrorStatus.ORDER_NOT_WAIT_PAY);
     }
+    this.status = OrderStatus.WAIT_PAY_CHECK;
+  }
 
-    public static Order create(
-            GroupBuyPost post,
-            User user,
-            DeliveryMethod method,
-            int totalAmount,
-            DeliveryInfo deliveryInfo,
-            String requestInfo
-    ) {
-        return Order.builder()
-                .groupBuyPost(post)
-                .user(user)
-                .deliveryMethod(method)
-                .totalAmount(totalAmount)
-                .deliveryInfo(deliveryInfo)
-                .requestInfo(requestInfo)
-                .build();
+  public void confirmPayment() {
+    if (this.status != OrderStatus.WAIT_PAY_CHECK) {
+      throw new BusinessException(ErrorStatus.ORDER_NOT_WAIT_PAY_CHECK);
     }
-    public void requestPayCheck() {
-        if (this.status != OrderStatus.WAIT_PAY) {
-            throw new BusinessException(ErrorStatus.ORDER_NOT_WAIT_PAY);
-        }
-        this.status = OrderStatus.WAIT_PAY_CHECK;
-    }
+    this.status = OrderStatus.PAID;
+  }
 
-    public void confirmPayment() {
-        if (this.status != OrderStatus.WAIT_PAY_CHECK) {
-            throw new BusinessException(ErrorStatus.ORDER_NOT_WAIT_PAY_CHECK);
-        }
-        this.status = OrderStatus.PAID;
-    }
+  // 주문 상태 변경 메서드
+  public void updateStatus(OrderStatus status) {
+    this.status = status;
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/order/entity/OrderStatus.java
+++ b/src/main/java/org/sopt/poti/domain/order/entity/OrderStatus.java
@@ -1,12 +1,12 @@
 package org.sopt.poti.domain.order.entity;
 
 public enum OrderStatus {
-    WAIT_PAY, // 입금 대기
-    WAIT_PAY_CHECK, //입금 확인 대기
-    PAID, //입금 완료
+  WAIT_PAY, // 입금 대기
+  WAIT_PAY_CHECK, //입금 확인 대기
+  PAID, //입금 완료
 
-    //배송 관련 상태값
-    READY, //배송 준비중
-    SHIPPED, //배송중
-    DELIVERED //배송 완료
+  //배송 관련 상태값
+  READY, //배송 대기
+  SHIPPED, //배송 시작
+  DELIVERED //배송 완료
 }

--- a/src/main/java/org/sopt/poti/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/sopt/poti/domain/order/repository/OrderRepository.java
@@ -1,11 +1,11 @@
 package org.sopt.poti.domain.order.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.sopt.poti.domain.order.entity.Order;
 import org.sopt.poti.domain.order.entity.OrderStatus;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,4 +25,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
   @Query("SELECT COUNT(o) FROM Order o WHERE o.groupBuyPost.id = :postId AND o.status <> :status")
   long countUnpaidOrders(@Param("postId") Long postId, @Param("status") OrderStatus status);
+
+  @Query("SELECT o FROM Order o JOIN FETCH o.groupBuyPost p JOIN FETCH p.leader WHERE o.id = :orderId")
+  Optional<Order> findByIdWithPostAndLeader(@Param("orderId") Long orderId);
 }

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
@@ -1,7 +1,13 @@
 package org.sopt.poti.domain.order.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.delivery.dto.request.StartDeliveryRequest;
+import org.sopt.poti.domain.delivery.dto.response.StartDeliveryResponse;
+import org.sopt.poti.domain.delivery.entity.Delivery;
+import org.sopt.poti.domain.delivery.service.DeliveryService;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
 import org.sopt.poti.domain.order.entity.Order;
 import org.sopt.poti.domain.order.entity.OrderItem;
 import org.sopt.poti.domain.order.entity.OrderStatus;
@@ -19,6 +25,7 @@ public class OrderService {
 
   private final OrderRepository orderRepository;
   private final OrderItemRepository orderItemRepository;
+  private final DeliveryService deliveryService;
 
   public int countByUser_Id(Long userId) {
     return orderRepository.countByUser_Id(userId);
@@ -57,5 +64,32 @@ public class OrderService {
   // 해당 분철글에 대해 OrderStatus가 아닌 주문이 남아있는지 확인
   public long countByGroupBuyPostIdAndStatusNot(Long postId, OrderStatus status) {
     return orderRepository.countUnpaidOrders(postId, status);
+  }
+
+  // 배송사 등록
+  @Transactional
+  public StartDeliveryResponse startOrderDelivery(Long userId, Long orderId,
+      StartDeliveryRequest startDeliveryRequest) {
+    Order order = orderRepository.findByIdWithPostAndLeader(orderId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.ORDER_NOT_FOUND));
+
+    GroupBuyPost groupBuyPost = order.getGroupBuyPost();
+    // 분철글이 본인이 작성한 글인지 확인
+    if (!groupBuyPost.getLeader().getId().equals(userId)) {
+      throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
+    }
+
+    Delivery delivery = Delivery.builder()
+        .trackingNumber(startDeliveryRequest.trackingNumber())
+        .carrier(startDeliveryRequest.carrier())
+        .shippedAt(LocalDateTime.now())
+        .order(order)
+        .build();
+
+    deliveryService.saveDelivery(delivery);
+    order.updateStatus(OrderStatus.DELIVERED);
+
+    return new StartDeliveryResponse(orderId, order.getStatus(),
+        startDeliveryRequest.trackingNumber(), LocalDateTime.now());
   }
 }

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
@@ -78,18 +78,19 @@ public class OrderService {
     if (!groupBuyPost.getLeader().getId().equals(userId)) {
       throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
     }
+    LocalDateTime shippedAt = LocalDateTime.now();
 
     Delivery delivery = Delivery.builder()
         .trackingNumber(startDeliveryRequest.trackingNumber())
         .carrier(startDeliveryRequest.carrier())
-        .shippedAt(LocalDateTime.now())
+        .shippedAt(shippedAt)
         .order(order)
         .build();
 
     deliveryService.saveDelivery(delivery);
-    order.updateStatus(OrderStatus.DELIVERED);
+    order.startDelivery();
 
     return new StartDeliveryResponse(orderId, order.getStatus(),
-        startDeliveryRequest.trackingNumber(), LocalDateTime.now());
+        startDeliveryRequest.trackingNumber(), shippedAt);
   }
 }

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
@@ -78,10 +78,10 @@ public class OrderService {
     if (!groupBuyPost.getLeader().getId().equals(userId)) {
       throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
     }
-    
+
     // 이미 배송 처리된 주문건
     if (deliveryService.existsDeliveryByOrderId(orderId)) {
-      throw new BusinessException(ErrorStatus.ORDER_EXSIST_SHIPPINGS);
+      throw new BusinessException(ErrorStatus.ORDER_EXISTS_SHIPPINGS);
     }
 
     LocalDateTime shippedAt = LocalDateTime.now();

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
@@ -73,16 +73,17 @@ public class OrderService {
     Order order = orderRepository.findByIdWithPostAndLeader(orderId)
         .orElseThrow(() -> new BusinessException(ErrorStatus.ORDER_NOT_FOUND));
 
-    // 이미 배송 처리된 주문건
-    if (deliveryService.existsDeliveryByOrderId(orderId)) {
-      throw new BusinessException(ErrorStatus.ORDER_EXSIST_SHIPPINGS);
-    }
-    
     GroupBuyPost groupBuyPost = order.getGroupBuyPost();
     // 분철글이 본인이 작성한 글인지 확인
     if (!groupBuyPost.getLeader().getId().equals(userId)) {
       throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
     }
+    
+    // 이미 배송 처리된 주문건
+    if (deliveryService.existsDeliveryByOrderId(orderId)) {
+      throw new BusinessException(ErrorStatus.ORDER_EXSIST_SHIPPINGS);
+    }
+
     LocalDateTime shippedAt = LocalDateTime.now();
 
     Delivery delivery = Delivery.builder()

--- a/src/main/java/org/sopt/poti/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/poti/global/config/SwaggerConfig.java
@@ -5,27 +5,41 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
-    private static final String SECURITY_SCHEME_NAME = "authorization";
+  private static final String SECURITY_SCHEME_NAME = "authorization";
 
-    @Bean
-    public OpenAPI openAPI() {
-        return new OpenAPI()
-                .components(new Components()
-                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
-                                .name(SECURITY_SCHEME_NAME)
-                                .type(SecurityScheme.Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")))
-                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
-                .info(new Info()
-                        .title("POTI Server API")
-                        .description("POTI 서비스 API 명세서")
-                        .version("1.0.0"));
-    }
+  @Bean
+  public OpenAPI openAPI() {
+
+    // 운영 서버 (HTTPS 필수)
+    Server prodServer = new Server();
+    prodServer.setUrl("https://poti.kr");
+    prodServer.setDescription("운영 서버 (Production)");
+
+    // 로컬 서버 (개발용)
+    Server localServer = new Server();
+    localServer.setUrl("http://localhost:8080");
+    localServer.setDescription("로컬 서버 (Local)");
+
+    return new OpenAPI()
+        .components(new Components()
+            .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                .name(SECURITY_SCHEME_NAME)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")))
+        .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+        .info(new Info()
+            .title("POTI Server API")
+            .description("POTI 서비스 API 명세서")
+            .version("1.0.0"))
+        .servers(List.of(prodServer, localServer));
+  }
 }

--- a/src/main/java/org/sopt/poti/global/error/ErrorStatus.java
+++ b/src/main/java/org/sopt/poti/global/error/ErrorStatus.java
@@ -9,19 +9,20 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ErrorStatus {
 
-    /**
-     * 400 Bad Request
-     */
-    BAD_REQUEST(40000, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    INVALID_NICKNAME(40001, HttpStatus.BAD_REQUEST, "닉네임 형식이 올바르지 않습니다."), // 특수문자랑 길이 검사
-    PROFANITY_DETECTED(40002, HttpStatus.BAD_REQUEST, "비속어가 포함되어 있습니다."),
-    NICKNAME_DUPLICATED(40003, HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
-    INVALID_SOCIAL_TYPE(40004, HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다."),
-    ORDER_NOT_COMPLETED(40005, HttpStatus.BAD_REQUEST, "거래 완료(배송 완료) 후에만 리뷰를 작성할 수 있습니다."),
-    PAYMENT_NOT_PENDING(40006, HttpStatus.BAD_REQUEST, "입금 대기 상태에서만 입금 정보를 제출할 수 있습니다."),
-    PAYMENT_NOT_REQUESTED(40007, HttpStatus.BAD_REQUEST, "입금 확인 대기 상태에서만 입금 확인이 가능합니다."),
-    ORDER_NOT_WAIT_PAY(40008, HttpStatus.BAD_REQUEST, "입금 대기 상태에서만 입금 정보를 제출할 수 있습니다."),
-    ORDER_NOT_WAIT_PAY_CHECK(40009, HttpStatus.BAD_REQUEST, "입금 확인 대기 상태에서만 입금 완료 처리가 가능합니다."),
+  /**
+   * 400 Bad Request
+   */
+  BAD_REQUEST(40000, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+  INVALID_NICKNAME(40001, HttpStatus.BAD_REQUEST, "닉네임 형식이 올바르지 않습니다."), // 특수문자랑 길이 검사
+  PROFANITY_DETECTED(40002, HttpStatus.BAD_REQUEST, "비속어가 포함되어 있습니다."),
+  NICKNAME_DUPLICATED(40003, HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
+  INVALID_SOCIAL_TYPE(40004, HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다."),
+  ORDER_NOT_COMPLETED(40005, HttpStatus.BAD_REQUEST, "거래 완료(배송 완료) 후에만 리뷰를 작성할 수 있습니다."),
+  PAYMENT_NOT_PENDING(40006, HttpStatus.BAD_REQUEST, "입금 대기 상태에서만 입금 정보를 제출할 수 있습니다."),
+  PAYMENT_NOT_REQUESTED(40007, HttpStatus.BAD_REQUEST, "입금 확인 대기 상태에서만 입금 확인이 가능합니다."),
+  ORDER_NOT_WAIT_PAY(40008, HttpStatus.BAD_REQUEST, "입금 대기 상태에서만 입금 정보를 제출할 수 있습니다."),
+  ORDER_NOT_WAIT_PAY_CHECK(40009, HttpStatus.BAD_REQUEST, "입금 확인 대기 상태에서만 입금 완료 처리가 가능합니다."),
+  ORDER_NOT_PAID_OR_READY(40010, HttpStatus.BAD_REQUEST, "입금 완료 상태 또는 배송 대기 상태에서만 배송 중 처리가 가능합니다."),
 
   /**
    * 401 Unauthorized
@@ -51,7 +52,7 @@ public enum ErrorStatus {
   DELIVERY_METHOD_NOT_FOUND(40405, HttpStatus.NOT_FOUND, "존재하지 않는 배송 방법입니다."),
   ORDER_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
   POST_NOT_FOUND(40407, HttpStatus.NOT_FOUND, "존재하지 않는 분철글입니다."),
-    PAYMENT_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "존재하지 않는 결제 정보입니다."),
+  PAYMENT_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "존재하지 않는 결제 정보입니다."),
 
   /**
    * 409 Conflict

--- a/src/main/java/org/sopt/poti/global/error/ErrorStatus.java
+++ b/src/main/java/org/sopt/poti/global/error/ErrorStatus.java
@@ -27,7 +27,7 @@ public enum ErrorStatus {
   GROUP_BUY_OPTION_NOT_IN_POST(40012, HttpStatus.BAD_REQUEST, "해당 분철글에 속하지 않은 옵션이 포함되어 있습니다."),
   DUPLICATE_ORDER_OPTION(40013, HttpStatus.BAD_REQUEST, "중복된 옵션은 한 주문에서 선택할 수 없습니다."),
   ORDER_NOT_PAID_OR_READY(40014, HttpStatus.BAD_REQUEST, "입금 완료 상태 또는 배송 대기 상태에서만 배송 중 처리가 가능합니다."),
-  ORDER_EXSIST_SHIPPINGS(40015, HttpStatus.BAD_REQUEST, "이미 배송처리된 주문입니다."),
+  ORDER_EXISTS_SHIPPINGS(40015, HttpStatus.BAD_REQUEST, "이미 배송처리된 주문입니다."),
 
   /**
    * 401 Unauthorized


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #65 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

  1. 운송장 등록 API 구현 (PATCH /api/v1/payments/orders/{orderId}/deliveries)
   - 총대가 주문에 대해 운송장 번호와 배송사를 등록하는 기능을 구현했습니다.
   - PaymentController 및 OrderService에 startOrderDelivery 메서드를 추가했습니다.
   - 운송장 등록 시 주문 상태를 업데이트하고, StartDeliveryResponse를 반환합니다.

  2. 주문 조회 성능 최적화 (N+1 문제 해결)
   - OrderRepository에 findByIdWithPostAndLeader 메서드를 추가했습니다.
   - Fetch Join을 사용하여 Order 조회 시 GroupBuyPost와 Leader(User)를 한 번의 쿼리로 함께 가져오도록 최적화했습니다.
   - 이를 통해 권한 체크 로직(order.getGroupBuyPost().getLeader())에서 발생하던 불필요한 추가 쿼리를 제거했습니다.

  3. 기타 개선
   - 상태 값 정의: OrderStatus Enum에 배송 관련 상태(SHIPPED, DELIVERED 등)가 정의되어 있음을 확인하고 활용했습니다.
   - 예외 처리: 권한 없는 유저 접근 시 FORBIDDEN_USER 예외를 발생시키도록 처리했습니다.

## 📸 테스트 증명 (필수) 
<img width="1082" height="1248" alt="image" src="https://github.com/user-attachments/assets/470715d2-2d5c-462d-aba7-aab92503393b" />

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
   - 주문 상태: 운송장 등록 시 주문 상태를 DELIVERED로 변경하도록 구현했습니다. (기획에 따라 SHIPPED로 변경 가능성 있음)
   - Fetch Join: OrderService의 주요 메서드(startOrderDelivery, confirmPayment 등)에서 N+1 방지를 위해 Fetch Join 메서드를 적극 활용했습니다.

##  ✅ 체크리스트
   - [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
   - [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
   - [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
   - [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 주문별 배송 시작 API 추가: 운송사·추적번호 등록으로 배송 시작 및 배송 정보 저장
  * 배송 데이터 저장을 위한 저장소·서비스 추가
  * 배송 조회 경로 일부 변경(공개 API 경로 정비)

* **Bug Fixes / Behavior**
  * 주문 상태 전환 검증 강화: 결제/배송 준비 상태에서만 배송 시작 허용
  * 권한 검증 강화: 해당 포스트 리더만 배송 시작 가능
  * 이미 배송된 주문에 대한 오류 처리 추가

* **Documentation**
  * OpenAPI 서버 목록(프로덕션/로컬) 업데이트 및 오류 메시지 보강

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->