### PR TITLE
[FEAT] 아티스트 자동완성 검색 (분철 글쓰기용) API 구현

### DIFF
--- a/src/main/java/org/sopt/poti/domain/artist/dto/response/ArtistTitlesResponse.java
+++ b/src/main/java/org/sopt/poti/domain/artist/dto/response/ArtistTitlesResponse.java
@@ -1,0 +1,12 @@
+package org.sopt.poti.domain.artist.dto.response;
+
+import java.util.List;
+
+public record ArtistTitlesResponse(
+    List<String> titles
+) {
+
+  public static ArtistTitlesResponse of(List<String> titles) {
+    return new ArtistTitlesResponse(titles);
+  }
+}

--- a/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepository.java
+++ b/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ArtistRepository extends JpaRepository<Artist, Long> {
+public interface ArtistRepository extends JpaRepository<Artist, Long>, ArtistRepositoryCustom {
+
 }

--- a/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryCustom.java
+++ b/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryCustom.java
@@ -1,0 +1,8 @@
+package org.sopt.poti.domain.artist.repository;
+
+import java.util.List;
+
+public interface ArtistRepositoryCustom {
+
+  List<String> findNamesByPrefix(String keyword, int limit);
+}

--- a/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryImpl.java
@@ -1,0 +1,25 @@
+package org.sopt.poti.domain.artist.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.artist.entity.QArtist;
+
+@RequiredArgsConstructor
+public class ArtistRepositoryImpl implements ArtistRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<String> findNamesByPrefix(String keyword, int limit) {
+    QArtist artist = QArtist.artist;
+
+    return queryFactory
+        .selectDistinct(artist.name)
+        .from(artist)
+        .where(artist.name.startsWithIgnoreCase(keyword))
+        .orderBy(artist.name.asc())
+        .limit(limit)
+        .fetch();
+  }
+}

--- a/src/main/java/org/sopt/poti/domain/artist/service/ArtistService.java
+++ b/src/main/java/org/sopt/poti/domain/artist/service/ArtistService.java
@@ -3,6 +3,7 @@ package org.sopt.poti.domain.artist.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.artist.dto.response.ArtistListResponse;
+import org.sopt.poti.domain.artist.dto.response.ArtistTitlesResponse;
 import org.sopt.poti.domain.artist.dto.response.MemberListResponse;
 import org.sopt.poti.domain.artist.dto.response.MemberListResponse.MemberResponse;
 import org.sopt.poti.domain.artist.entity.Artist;
@@ -51,4 +52,14 @@ public class ArtistService {
 
     return new MemberListResponse(list);
   }
+
+  public ArtistTitlesResponse searchArtists(String keyword) {
+    if (keyword == null || keyword.trim().isEmpty()) {
+      return ArtistTitlesResponse.of(List.of());
+    }
+
+    List<String> titles = artistRepository.findNamesByPrefix(keyword.trim(), 5);
+    return ArtistTitlesResponse.of(titles);
+  }
+
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
@@ -6,6 +6,8 @@ import jakarta.validation.Valid;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.artist.dto.response.ArtistTitlesResponse;
+import org.sopt.poti.domain.artist.service.ArtistService;
 import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyCreateRequest;
 import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyListRequest;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyCreateResponse;
@@ -39,6 +41,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class GroupBuyController {
 
   private final GroupBuyService groupBuyService;
+  private final ArtistService artistService;
 
   @PostMapping
   @Operation(summary = "공동구매 게시글 등록", description = "새로운 공동구매 게시글을 등록합니다.")
@@ -101,5 +104,13 @@ public class GroupBuyController {
     GroupBuyPostOptionResponse groupBuyPostOptionResponse = groupBuyService.getGroupBuyPostOptionResponse(
         postId);
     return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, groupBuyPostOptionResponse));
+  }
+
+  @GetMapping("/artists")
+  @Operation(summary = "아티스트 실시간 검색 자동완성/추천", description = "입력 키워드를 기반으로 아티스트명을 추천합니다.")
+  public ApiResponse<ArtistTitlesResponse> searchArtists(
+      @RequestParam String keyword
+  ) {
+    return ApiResponse.success(SuccessStatus.OK, artistService.searchArtists(keyword));
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #68

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
**아티스트 실시간 검색(자동완성) API 구현**
아티스트 검색 자동완성 기능을 구현했습니다.
사용자가 입력한 키워드를 기준으로 아티스트명 첫 글자가 일치하는 결과만 추천합니다.

**1. Artist 자동완성 API 추가**

- 입력 키워드(keyword)를 기반으로 아티스트명 리스트를 반환합니다.
- 응답 DTO로 ArtistTitlesResponse를 추가하여 자동완성 결과를 전달합니다.

**2. Repository 구조 정리 및 QueryDSL 적용**
- 기존 JPQL 기반 검색 로직을 제거하고,
- GroupBuy 도메인과 동일한 패턴으로 Custom Repository + QueryDSL 구조로 통일했습니다.
- ArtistRepositoryCustom / ArtistRepositoryImpl를 추가하여 검색 책임을 Custom Repository로 분리했습니다.
- QueryDSL의 startsWithIgnoreCase를 사용해 아티스트명이 입력 키워드로 시작하는 경우만 조회하도록 구현했습니다.

**3. 검색 정확도 개선**
- 기존 포함 검색(contains)이 아닌 prefix 검색을 적용하여 자동완성 UX에 맞는 결과만 반환하도록 개선했습니다.
- 중복 아티스트명은 selectDistinct로 제거하고, 이름 기준 오름차순 정렬 및 결과 개수 제한(limit)을 적용했습니다.

**4. Service 계층 역할 정리**
- ArtistService에서 입력값 검증(빈 값 처리)을 수행하고
- Custom Repository 메서드(findNamesByPrefix)를 호출하도록 구성했습니다.

## 📸 테스트 증명 (필수) 
- S 한글자 검색 시

<img width="1058" height="765" alt="image" src="https://github.com/user-attachments/assets/4a61e013-beae-4da2-9fb2-5b8be9cb50c4" />

- SE 두글자 검색 시

<img width="1062" height="674" alt="image" src="https://github.com/user-attachments/assets/ae42d017-3edf-4be3-921a-edd4a5549cb4" />


## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 아티스트 검색 기능 추가 - 사용자가 아티스트 이름으로 검색하여 일치하는 결과를 조회할 수 있는 새로운 검색 API가 추가되었습니다. 검색 결과는 최대 5개까지 표시되며 알파벳 순서로 정렬됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->