### PR TITLE
[FEAT] 내 분철글 목록 조회 API 구현 및 상태별 필터링 적용

### DIFF
--- a/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
@@ -8,9 +8,11 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyCreateRequest;
 import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyListRequest;
+import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyMeStatus;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyCreateResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyListResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyMeResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyTitlesResponse;
 import org.sopt.poti.domain.groupbuy.service.GroupBuyService;
@@ -101,5 +103,18 @@ public class GroupBuyController {
     GroupBuyPostOptionResponse groupBuyPostOptionResponse = groupBuyService.getGroupBuyPostOptionResponse(
         postId);
     return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, groupBuyPostOptionResponse));
+  }
+
+  @GetMapping("/me")
+  @Operation(summary = "판매자용 내 판매 내역 리스트 조회", description =
+      "총대로 진행했던 내역들을 조회합니다. 상태값은 IN_PROGRESS (진행중) \n"
+          + "또는\n"
+          + "COMPLETED (완료)가 있습니다.")
+  public ResponseEntity<ApiResponse<GroupBuyMeResponse>> getGroupBuyMeList(
+      @RequestParam(name = "status") GroupBuyMeStatus status,
+      @AuthenticationPrincipal UserPrincipal userPrincipal
+  ) {
+    GroupBuyMeResponse response = groupBuyService.getMyGroupBuyPosts(userPrincipal.getUserId(), status);
+    return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, response));
   }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyMeStatus.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyMeStatus.java
@@ -1,0 +1,6 @@
+package org.sopt.poti.domain.groupbuy.dto.request;
+
+public enum GroupBuyMeStatus {
+  IN_PROGRESS, // 진행중
+  COMPLETED // 종료
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyMeResponse.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/GroupBuyMeResponse.java
@@ -1,0 +1,24 @@
+package org.sopt.poti.domain.groupbuy.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyMeStatus;
+
+public record GroupBuyMeResponse(
+    Integer inProgressCount,  // 진행 중인 분철글 수
+    Integer completedCount,   // 종료된 분철글 수
+    GroupBuyMeStatus currentStatus, // 현재 필터링 조건
+    List<GroupBuyResponse> groupBuyPosts
+) {
+
+  public record GroupBuyResponse(
+      Long groupBuyId,  // 공구글 식별자
+      String artistName,  // 아티스트명
+      String productName, // 상품명
+      String thumbnailUrl,
+      String status,
+      LocalDateTime createdAt // 공구글 생성 시간
+  ) {
+
+  }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepository.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepository.java
@@ -23,4 +23,6 @@ public interface GroupBuyRepository extends JpaRepository<GroupBuyPost, Long>, G
     void deleteByLeaderId(Long leaderId);
 
     List<GroupBuyPost> findAllByLeaderId(Long leaderId);
+
+    List<GroupBuyPost> findByLeader_IdAndStatusInOrderByCreatedAtDesc(Long leaderId, List<GroupBuyPostStatus> statuses);
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -15,6 +15,7 @@ import org.sopt.poti.domain.delivery.entity.DeliveryMethod;
 import org.sopt.poti.domain.delivery.service.DeliveryService;
 import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyCreateRequest;
 import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyListRequest;
+import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyMeStatus;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyCreateResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.ImageResponse;
@@ -22,6 +23,7 @@ import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.Partici
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.ShippingResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyDetailResponse.UploaderResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyListResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyMeResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse.GroupBuyPostDeliveryOption;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse.GroupBuyPostMemberOption;
@@ -390,5 +392,45 @@ public class GroupBuyService {
     return post;
   }
 
+  public GroupBuyMeResponse getMyGroupBuyPosts(Long userId, GroupBuyMeStatus status) {
+    List<GroupBuyPostStatus> inProgressStatuses = List.of(
+        GroupBuyPostStatus.RECRUITING,
+        GroupBuyPostStatus.CLOSED,
+        GroupBuyPostStatus.PAYMENT_DONE,
+        GroupBuyPostStatus.SHIPPING
+    );
+    List<GroupBuyPostStatus> completedStatuses = List.of(
+        GroupBuyPostStatus.DELIVERED,
+        GroupBuyPostStatus.COMPLETED
+    );
 
+    List<GroupBuyPostStatus> targetStatuses = (status == GroupBuyMeStatus.IN_PROGRESS)
+        ? inProgressStatuses
+        : completedStatuses;
+
+    List<GroupBuyPost> posts = groupBuyRepository.findByLeader_IdAndStatusInOrderByCreatedAtDesc(
+        userId, targetStatuses);
+
+    List<GroupBuyMeResponse.GroupBuyResponse> groupBuyResponses = posts.stream()
+        .map(post -> new GroupBuyMeResponse.GroupBuyResponse(
+            post.getId(),
+            post.getArtist().getName(),
+            post.getTitle(),
+            post.getRepresentativeImageUrl(),
+            post.getStatus().name(),
+            post.getCreatedAt()
+        ))
+        .toList();
+
+    int inProgressCount = groupBuyRepository.countByLeader_IdAndStatusIn(userId,
+        inProgressStatuses);
+    int completedCount = groupBuyRepository.countByLeader_IdAndStatusIn(userId, completedStatuses);
+
+    return new GroupBuyMeResponse(
+        inProgressCount,
+        completedCount,
+        status,
+        groupBuyResponses
+    );
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #69 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
  1. 내 분철글 목록 조회 API 구현 (GET /api/v1/posts/me)
   - 총대(판매자)가 자신이 올린 분철글 목록을 조회하는 기능을 구현했습니다.
   - 필터링: status 파라미터(IN_PROGRESS, COMPLETED)를 통해 진행 중인 글과 완료된 글을 구분하여 조회합니다.
   - 상태 그룹핑:
       - IN_PROGRESS: RECRUITING, CLOSED, PAYMENT_DONE, SHIPPING
       - COMPLETED: DELIVERED, COMPLETED
   - 정렬: 생성일 기준 최신순(OrderByCreatedAtDesc)으로 정렬됩니다.
   - 카운트: 진행 중인 글과 완료된 글의 개수를 각각 계산하여 응답에 포함합니다.

  2. DTO 추가
   - GroupBuyMeStatus Enum: 요청 파라미터용 상태 정의.
   - GroupBuyMeResponse: 응답용 DTO (카운트 정보 및 게시글 리스트 포함).

  3. Repository 메서드 추가
   - GroupBuyRepository: findByLeader_IdAndStatusInOrderByCreatedAtDesc 메서드를 추가하여 상태 목록 기반 조회 및 최신순 정렬을 지원합니다. 

## 📸 테스트 증명 (필수) 
- 종료된 상태 (배송완료)
<img width="924" height="1510" alt="image" src="https://github.com/user-attachments/assets/987ff7f7-0284-45ff-a718-71a307a65c1f" />

- 진행중인 상태 (모집완료, 입금완료, 배송중)
<img width="996" height="1434" alt="image" src="https://github.com/user-attachments/assets/48830f2b-5661-4c13-acb2-55488c25beba" />


## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
   - 상태 매핑: 서비스 레이어에서 GroupBuyMeStatus를 List<GroupBuyPostStatus>로 매핑하여 쿼리합니다.
   - N+1 방지: 목록 조회 시 연관 엔티티(Artist 등) 접근이 필요하다면 Fetch Join이 필요할 수 있으나, 현재 DTO에는 간단한 정보만 포함되어 있어 기본 조회로 처리했습니다. (필요 시 EntityGraph 적용 가능)

## ✅ 체크리스트
   - [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
   - [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
   - [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
   - [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능

* 판매자의 공동구매 포스트 개인 조회 기능 추가
  * 진행 중 또는 완료된 상태별로 자신의 포스트 필터링 조회 가능
  * 각 포스트의 상세 정보 표시(아티스트명, 상품명, 썸네일, 상태, 생성일시)
  * 진행 중 및 완료된 포스트 수 집계 제공
  * 인증된 사용자 기준으로 자신의 게시물만 안전하게 조회됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->