### PR TITLE
[FEAT] 분철글 참여자 목록 조회 API 구현 및 배송 정보 NPE 해결

### DIFF
--- a/src/main/java/org/sopt/poti/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/org/sopt/poti/domain/delivery/service/DeliveryService.java
@@ -43,4 +43,8 @@ public class DeliveryService {
   public boolean existsDeliveryByOrderId(Long orderId) {
     return deliveryRepository.existsDeliveryByOrderId(orderId);
   }
+
+  public Delivery getDeliveryByOrderId(Long orderID) {
+    return deliveryRepository.findById(orderID).orElse(null);
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/org/sopt/poti/domain/delivery/service/DeliveryService.java
@@ -43,8 +43,4 @@ public class DeliveryService {
   public boolean existsDeliveryByOrderId(Long orderId) {
     return deliveryRepository.existsDeliveryByOrderId(orderId);
   }
-
-  public Delivery getDeliveryByOrderId(Long orderID) {
-    return deliveryRepository.findById(orderID).orElse(null);
-  }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
@@ -139,7 +139,7 @@ public class GroupBuyController {
       @PathVariable(name = "postId") Long postId
   ) {
     PostParticipantListResponse groupBuyParticipantList = groupBuyService.getGroupBuyParticipantList(
-        postId);
+        userPrincipal.getUserId(), postId);
     return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, groupBuyParticipantList));
   }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/controller/GroupBuyController.java
@@ -17,6 +17,7 @@ import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyListResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyMeResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyTitlesResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.PostParticipantListResponse;
 import org.sopt.poti.domain.groupbuy.service.GroupBuyService;
 import org.sopt.poti.global.common.ApiResponse;
 import org.sopt.poti.global.common.SuccessStatus;
@@ -117,7 +118,7 @@ public class GroupBuyController {
   }
 
   @GetMapping("/me")
-  @Operation(summary = "판매자용 내 판매 내역 리스트 조회", description =
+  @Operation(summary = "판매자 - 내 판매 내역 리스트 조회", description =
       "총대로 진행했던 내역들을 조회합니다. 상태값은 IN_PROGRESS (진행중) \n"
           + "또는\n"
           + "COMPLETED (완료)가 있습니다.")
@@ -128,5 +129,17 @@ public class GroupBuyController {
     GroupBuyMeResponse response = groupBuyService.getMyGroupBuyPosts(userPrincipal.getUserId(),
         status);
     return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, response));
+  }
+
+  @GetMapping("/{postId}/participants")
+  @Operation(summary = "판매자 - 특정 분철글의 참여자 목록 조회", description = "특정 분철글의 참여자 목록을 조회합니다."
+      + "\nOrderStatus별로 주는 값이 달라집니다. 컬럼이 사라지진 않고, null로 반환합니다.")
+  public ResponseEntity<ApiResponse<PostParticipantListResponse>> getGroupBuyParticipantList(
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
+      @PathVariable(name = "postId") Long postId
+  ) {
+    PostParticipantListResponse groupBuyParticipantList = groupBuyService.getGroupBuyParticipantList(
+        postId);
+    return ResponseEntity.ok(ApiResponse.success(SuccessStatus.OK, groupBuyParticipantList));
   }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/PostParticipantListResponse.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/PostParticipantListResponse.java
@@ -1,7 +1,6 @@
 package org.sopt.poti.domain.groupbuy.dto.response;
 
 import java.util.List;
-import org.sopt.poti.domain.order.entity.OrderStatus;
 
 public record PostParticipantListResponse(
     List<PostParticipantResponse> participants
@@ -13,7 +12,7 @@ public record PostParticipantListResponse(
       String profileImage,
       String nickname,
       List<String> memberNames, // 구매한 아티스트 멤버들 (클라이언트에서 유진, 레이 로 이어서 사용)
-      OrderStatus status, // 해당 주문 상태
+      String status, // 해당 주문 상태
       PriceInfo priceInfo,  // 금액 정보
       DepositInfo depositInfo,  // 입금 정보
       ShippingInfo shippingInfo // 배송 정보

--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/PostParticipantListResponse.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/response/PostParticipantListResponse.java
@@ -1,0 +1,58 @@
+package org.sopt.poti.domain.groupbuy.dto.response;
+
+import java.util.List;
+import org.sopt.poti.domain.order.entity.OrderStatus;
+
+public record PostParticipantListResponse(
+    List<PostParticipantResponse> participants
+) {
+
+  public record PostParticipantResponse(
+      Long orderId,
+      Long userId,
+      String profileImage,
+      String nickname,
+      List<String> memberNames, // 구매한 아티스트 멤버들 (클라이언트에서 유진, 레이 로 이어서 사용)
+      OrderStatus status, // 해당 주문 상태
+      PriceInfo priceInfo,  // 금액 정보
+      DepositInfo depositInfo,  // 입금 정보
+      ShippingInfo shippingInfo // 배송 정보
+  ) {
+
+  }
+
+  // 입금해야할 금액 정보
+  public record PriceInfo(
+      List<MemberPerPrice> memberPerPrices,
+      String shippingName,
+      Integer shippingPrice,
+      Integer totalPrice
+  ) {
+
+  }
+
+  public record MemberPerPrice(
+      String name,  // 아티스트 멤버 이름
+      Integer price // 아티스트 멤버 굿즈 가격
+  ) {
+
+  }
+
+  // 입금정보
+  public record DepositInfo(
+      String depositorName,
+      String depositTime
+  ) {
+
+  }
+
+  // 배송 정보
+  public record ShippingInfo(
+      String receiverName,  // 받는 사람 정보
+      String address,
+      String phone, // 휴대폰 번호
+      String trackingNumber // 송장 번호
+  ) {
+
+  }
+}

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -28,6 +28,7 @@ import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse.GroupBuyPostDeliveryOption;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPostOptionResponse.GroupBuyPostMemberOption;
 import org.sopt.poti.domain.groupbuy.dto.response.GroupBuyPotItem;
+import org.sopt.poti.domain.groupbuy.dto.response.PostParticipantListResponse;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyOption;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
@@ -432,5 +433,13 @@ public class GroupBuyService {
         status,
         groupBuyResponses
     );
+  }
+
+  // 특정 분철글 참여자 목록 조회
+  public PostParticipantListResponse getGroupBuyParticipantList(Long postId) {
+    GroupBuyPost groupBuyPost = groupBuyRepository.findById(postId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.POST_NOT_FOUND));
+
+    return orderService.findParticipants(groupBuyPost.getId());
   }
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -436,10 +436,13 @@ public class GroupBuyService {
   }
 
   // 특정 분철글 참여자 목록 조회
-  public PostParticipantListResponse getGroupBuyParticipantList(Long postId) {
+  public PostParticipantListResponse getGroupBuyParticipantList(Long userId, Long postId) {
     GroupBuyPost groupBuyPost = groupBuyRepository.findById(postId)
         .orElseThrow(() -> new BusinessException(ErrorStatus.POST_NOT_FOUND));
-
+    if (!groupBuyPost.getLeader().getId().equals(userId)) {
+      throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
+    }
+    
     return orderService.findParticipants(groupBuyPost.getId());
   }
 

--- a/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/service/GroupBuyService.java
@@ -442,4 +442,9 @@ public class GroupBuyService {
 
     return orderService.findParticipants(groupBuyPost.getId());
   }
+
+  public GroupBuyPost getGroupBuyPostById(Long postId) {
+    return groupBuyRepository.findById(postId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.POST_NOT_FOUND));
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/order/entity/Order.java
+++ b/src/main/java/org/sopt/poti/domain/order/entity/Order.java
@@ -22,6 +22,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.poti.domain.delivery.entity.Delivery;
 import org.sopt.poti.domain.delivery.entity.DeliveryMethod;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
 import org.sopt.poti.domain.payment.entity.Payment;
@@ -74,6 +75,9 @@ public class Order extends BaseTimeEntity {
 
   @OneToOne(mappedBy = "order", fetch = FetchType.LAZY)
   private Review review;
+
+  @OneToOne(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+  private Delivery delivery;
 
   @Builder
   private Order(

--- a/src/main/java/org/sopt/poti/domain/order/entity/Order.java
+++ b/src/main/java/org/sopt/poti/domain/order/entity/Order.java
@@ -69,8 +69,8 @@ public class Order extends BaseTimeEntity {
   @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
   private final List<OrderItem> orderItems = new ArrayList<>();
 
-  @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
-  private final List<Payment> payments = new ArrayList<>();
+  @OneToOne(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+  private Payment payment;
 
   @OneToOne(mappedBy = "order", fetch = FetchType.LAZY)
   private Review review;

--- a/src/main/java/org/sopt/poti/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/sopt/poti/domain/order/repository/OrderRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
 
   int countByUser_Id(Long userId);
 

--- a/src/main/java/org/sopt/poti/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/org/sopt/poti/domain/order/repository/OrderRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.sopt.poti.domain.order.repository;
+
+import java.util.List;
+import org.sopt.poti.domain.order.entity.Order;
+
+public interface OrderRepositoryCustom {
+
+  List<Order> findAllOrdersWithBasicInfo(Long postId);
+}

--- a/src/main/java/org/sopt/poti/domain/order/repository/OrderRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/order/repository/OrderRepositoryImpl.java
@@ -1,0 +1,34 @@
+package org.sopt.poti.domain.order.repository;
+
+import static org.sopt.poti.domain.delivery.entity.QDeliveryMethod.deliveryMethod;
+import static org.sopt.poti.domain.order.entity.QOrder.order;
+import static org.sopt.poti.domain.user.entity.QUser.user;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.order.entity.Order;
+
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Order> findAllOrdersWithBasicInfo(Long postId) {
+
+    return queryFactory
+        .selectFrom(order)
+        // User와 DeliveryMethod를 한 방에 가져옴 (Fetch Join)
+        .join(order.user, user).fetchJoin()
+        .join(order.deliveryMethod, deliveryMethod).fetchJoin()
+
+        // 조건: 해당 분철글(postId)의 주문만
+        .where(order.groupBuyPost.id.eq(postId))
+
+        // 정렬: 최신순
+        .orderBy(order.createdAt.desc())
+        .fetch();
+  }
+
+}

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
@@ -15,6 +15,7 @@ import org.sopt.poti.domain.groupbuy.dto.response.PostParticipantListResponse.Po
 import org.sopt.poti.domain.groupbuy.dto.response.PostParticipantListResponse.PriceInfo;
 import org.sopt.poti.domain.groupbuy.dto.response.PostParticipantListResponse.ShippingInfo;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
+import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
 import org.sopt.poti.domain.order.entity.DeliveryInfo;
 import org.sopt.poti.domain.order.entity.Order;
 import org.sopt.poti.domain.order.entity.OrderItem;
@@ -122,15 +123,21 @@ public class OrderService {
 
     // 2. DTO 변환 (여기서 배치 로딩으로 연관 데이터 쿼리 나감)
     List<PostParticipantResponse> participantResponses = orders.stream()
-        .map(this::convertToParticipantResponse)
+        .map(order -> convertToParticipantResponse(order.getGroupBuyPost().getStatus(), order)
+        )
         .toList();
 
     return new PostParticipantListResponse(participantResponses);
   }
 
   // 단일 주문을 응답 DTO로 변환하는 메인 로직
-  private PostParticipantResponse convertToParticipantResponse(Order order) {
-    OrderStatus status = order.getStatus();
+  private PostParticipantResponse convertToParticipantResponse(
+      GroupBuyPostStatus groupBuyPostStatus, Order order) {
+    String status = order.getStatus().name();
+
+    if (groupBuyPostStatus.equals(GroupBuyPostStatus.RECRUITING)) {
+      status = groupBuyPostStatus.name();
+    }
 
     return new PostParticipantResponse(
         order.getId(),
@@ -145,9 +152,7 @@ public class OrderService {
     );
   }
 
-  // -------------------------------------------------------------
-  // Helper Methods (조건 로직 분리)
-  // -------------------------------------------------------------
+  //=== Helper Methods (조건 로직 분리) ===//
 
   // 1. 멤버 이름 리스트 추출
   private List<String> getMemberNames(Order order) {
@@ -174,9 +179,10 @@ public class OrderService {
   }
 
   // 3. 입금 정보 생성 (입금 확인중 이상부터 노출)
-  private DepositInfo createDepositInfo(Order order, OrderStatus status) {
-    // 모집 대기(WAIT_PAY) 상태면 안 보여줌
-    if (status == OrderStatus.WAIT_PAY) {
+  private DepositInfo createDepositInfo(Order order, String status) {
+    // 분철글 모집 대기(WAIT_PAY) 상태면 안 보여줌 && 입금 대기 중 상태면 안보여줌
+    if (Objects.equals(status, OrderStatus.WAIT_PAY.name()) || Objects.equals(status,
+        GroupBuyPostStatus.RECRUITING.name())) {
       return null;
     }
 
@@ -190,20 +196,13 @@ public class OrderService {
     } else {
       return null;
     }
-
-//    return order.getPayments().stream()
-//        .findFirst() // 가장 최근 입금 내역
-//        .map(payment -> new DepositInfo(
-//            payment.getDepositorName(),
-//            payment.getDepositedAt().toString() // 포맷팅 필요 시 Utils 사용
-//        ))
-//        .orElse(null); // 데이터가 없으면 null
   }
 
   // 4. 배송 정보 생성 (입금 완료 이상부터 노출)
-  private ShippingInfo createShippingInfo(Order order, OrderStatus status) {
+  private ShippingInfo createShippingInfo(Order order, String status) {
     // 모집 대기(WAIT_PAY) or 입금 확인중(WAIT_PAY_CHECK)이면 안 보여줌
-    if (status == OrderStatus.WAIT_PAY || status == OrderStatus.WAIT_PAY_CHECK) {
+    if (status.equals(OrderStatus.WAIT_PAY.name()) || status.equals(
+        OrderStatus.WAIT_PAY_CHECK.name()) || status.equals(GroupBuyPostStatus.RECRUITING.name())) {
       return null;
     }
 

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
@@ -2,17 +2,26 @@ package org.sopt.poti.domain.order.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.delivery.dto.request.StartDeliveryRequest;
 import org.sopt.poti.domain.delivery.dto.response.StartDeliveryResponse;
 import org.sopt.poti.domain.delivery.entity.Delivery;
 import org.sopt.poti.domain.delivery.service.DeliveryService;
+import org.sopt.poti.domain.groupbuy.dto.response.PostParticipantListResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.PostParticipantListResponse.DepositInfo;
+import org.sopt.poti.domain.groupbuy.dto.response.PostParticipantListResponse.MemberPerPrice;
+import org.sopt.poti.domain.groupbuy.dto.response.PostParticipantListResponse.PostParticipantResponse;
+import org.sopt.poti.domain.groupbuy.dto.response.PostParticipantListResponse.PriceInfo;
+import org.sopt.poti.domain.groupbuy.dto.response.PostParticipantListResponse.ShippingInfo;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
+import org.sopt.poti.domain.order.entity.DeliveryInfo;
 import org.sopt.poti.domain.order.entity.Order;
 import org.sopt.poti.domain.order.entity.OrderItem;
 import org.sopt.poti.domain.order.entity.OrderStatus;
 import org.sopt.poti.domain.order.repository.OrderItemRepository;
 import org.sopt.poti.domain.order.repository.OrderRepository;
+import org.sopt.poti.domain.payment.entity.Payment;
 import org.sopt.poti.global.error.BusinessException;
 import org.sopt.poti.global.error.ErrorStatus;
 import org.springframework.stereotype.Service;
@@ -98,5 +107,123 @@ public class OrderService {
 
     return new StartDeliveryResponse(orderId, order.getStatus(),
         startDeliveryRequest.trackingNumber(), shippedAt);
+  }
+
+  // post에 참여한 사용자 조회
+  public PostParticipantListResponse findParticipants(Long postId) {
+    List<Order> orders = orderRepository.findAllOrdersWithBasicInfo(postId);
+
+    // 공통 - 참여한 멤버옵션들, OrderStatus, PostParticipantResponse (DepositInfo, ShippingInfo 제외)
+    // 1. 모집대기 - 공통만
+    // 2. 입금 확인중 - 공통 + DepositInfo
+    // 3. 입금 완료 - ShippingInfo(송장번호 null)
+    // 4. 배송 시작 - ShippingInfo
+    // 5. 배송 완료 - ShippingInfo(송장번호만)
+
+    // 2. DTO 변환 (여기서 배치 로딩으로 연관 데이터 쿼리 나감)
+    List<PostParticipantResponse> participantResponses = orders.stream()
+        .map(this::convertToParticipantResponse)
+        .toList();
+
+    return new PostParticipantListResponse(participantResponses);
+  }
+
+  // 단일 주문을 응답 DTO로 변환하는 메인 로직
+  private PostParticipantResponse convertToParticipantResponse(Order order) {
+    OrderStatus status = order.getStatus();
+
+    return new PostParticipantResponse(
+        order.getId(),
+        order.getUser().getId(),
+        order.getUser().getProfileImageUrl(), // User는 이미 Fetch Join 됨
+        order.getUser().getNickname(),
+        getMemberNames(order),            // 아티스트 이름 리스트 추출
+        status,
+        createPriceInfo(order),           // 금액 정보 (항상 존재)
+        createDepositInfo(order, status), // 입금 정보 (조건부)
+        createShippingInfo(order, status) // 배송 정보 (조건부)
+    );
+  }
+
+  // -------------------------------------------------------------
+  // Helper Methods (조건 로직 분리)
+  // -------------------------------------------------------------
+
+  // 1. 멤버 이름 리스트 추출
+  private List<String> getMemberNames(Order order) {
+    return order.getOrderItems().stream()
+        .map(item -> item.getGroupBuyOption().getMember().getName())
+        .toList();
+  }
+
+  // 2. 금액 정보 생성 (항상 노출)
+  private PriceInfo createPriceInfo(Order order) {
+    List<MemberPerPrice> memberPerPrices = order.getOrderItems().stream()
+        .map(item -> new MemberPerPrice(
+            item.getGroupBuyOption().getMember().getName(),
+            item.getUnitPrice() // 단가
+        ))
+        .toList();
+
+    return new PriceInfo(
+        memberPerPrices,
+        order.getDeliveryMethod().getName(), // "준등기" 등
+        order.getDeliveryMethod().getPrice(),
+        order.getTotalAmount()
+    );
+  }
+
+  // 3. 입금 정보 생성 (입금 확인중 이상부터 노출)
+  private DepositInfo createDepositInfo(Order order, OrderStatus status) {
+    // 모집 대기(WAIT_PAY) 상태면 안 보여줌
+    if (status == OrderStatus.WAIT_PAY) {
+      return null;
+    }
+
+    // 만약 Payment가 없다면 null 처리
+    Payment payment = order.getPayment();
+    if (payment != null) {
+      return new DepositInfo(
+          payment.getDepositor(),
+          payment.getDepositedAt()
+      );
+    } else {
+      return null;
+    }
+
+//    return order.getPayments().stream()
+//        .findFirst() // 가장 최근 입금 내역
+//        .map(payment -> new DepositInfo(
+//            payment.getDepositorName(),
+//            payment.getDepositedAt().toString() // 포맷팅 필요 시 Utils 사용
+//        ))
+//        .orElse(null); // 데이터가 없으면 null
+  }
+
+  // 4. 배송 정보 생성 (입금 완료 이상부터 노출)
+  private ShippingInfo createShippingInfo(Order order, OrderStatus status) {
+    // 모집 대기(WAIT_PAY) or 입금 확인중(WAIT_PAY_CHECK)이면 안 보여줌
+    if (status == OrderStatus.WAIT_PAY || status == OrderStatus.WAIT_PAY_CHECK) {
+      return null;
+    }
+
+    // 상태: PAID(입금완료), SHIPPED, DELIVERED
+    DeliveryInfo info = order.getDeliveryInfo();
+    Delivery deliveryByOrderId = deliveryService.getDeliveryByOrderId(order.getId());
+
+    if (info == null && deliveryByOrderId == null) {
+      return null; // 방어 로직
+    }
+
+    // 송장번호가 null이면 null로 반환
+    String trackingNumber =
+        (deliveryByOrderId != null) ? deliveryByOrderId.getTrackingNumber() : null;
+
+    return new ShippingInfo(
+        Objects.requireNonNull(info).getReceiverName(),
+        info.getAddressLine(),
+        info.getPhone(),
+        trackingNumber
+    );
   }
 }

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
@@ -208,9 +208,9 @@ public class OrderService {
 
     // 상태: PAID(입금완료), SHIPPED, DELIVERED
     DeliveryInfo info = order.getDeliveryInfo();
-    Delivery deliveryByOrderId = deliveryService.getDeliveryByOrderId(order.getId());
+    Delivery deliveryByOrderId = order.getDelivery();
 
-    if (info == null && deliveryByOrderId == null) {
+    if (info == null) {
       return null; // 방어 로직
     }
 
@@ -218,8 +218,16 @@ public class OrderService {
     String trackingNumber =
         (deliveryByOrderId != null) ? deliveryByOrderId.getTrackingNumber() : null;
 
+    if (status.equals(OrderStatus.DELIVERED.name())) {
+      return new ShippingInfo(
+          null,
+          null,
+          null,
+          trackingNumber
+      );
+    }
     return new ShippingInfo(
-        Objects.requireNonNull(info).getReceiverName(),
+        info.getReceiverName(),
         info.getAddressLine(),
         info.getPhone(),
         trackingNumber

--- a/src/main/java/org/sopt/poti/domain/payment/entity/Payment.java
+++ b/src/main/java/org/sopt/poti/domain/payment/entity/Payment.java
@@ -1,11 +1,23 @@
 package org.sopt.poti.domain.payment.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.poti.domain.order.entity.Order;
+import org.sopt.poti.global.entity.BaseTimeEntity;
 import org.sopt.poti.global.error.BusinessException;
 import org.sopt.poti.global.error.ErrorStatus;
 
@@ -13,59 +25,59 @@ import org.sopt.poti.global.error.ErrorStatus;
 @Entity
 @Table(name = "payments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Payment {
+public class Payment extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Version
-    private Long version;
+  @Version
+  private Long version;
 
-    @Column(name = "depositor", length = 50)
-    private String depositor;
+  @Column(name = "depositor", length = 50)
+  private String depositor;
 
-    @Column(name = "deposited_at", length = 30)
-    private String depositedAt;
+  @Column(name = "deposited_at", length = 30)
+  private String depositedAt;
 
-    @Column(nullable = false)
-    private int amount;
+  @Column(nullable = false)
+  private int amount;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private PaymentStatus status;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private PaymentStatus status;
 
-    @Column(name = "confirmed_at")
-    private LocalDateTime confirmedAt;
+  @Column(name = "confirmed_at")
+  private LocalDateTime confirmedAt;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_id", nullable = false)
-    private Order order;
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "order_id", nullable = false)
+  private Order order;
 
-    public static Payment create(String depositor, int amount, Order order, String depositedAt) {
-        Payment p = new Payment();
-        p.depositor = depositor;
-        p.amount = amount;
-        p.order = order;
-        p.depositedAt = depositedAt;
-        p.status = PaymentStatus.PENDING;
-        return p;
+  public static Payment create(String depositor, int amount, Order order, String depositedAt) {
+    Payment p = new Payment();
+    p.depositor = depositor;
+    p.amount = amount;
+    p.order = order;
+    p.depositedAt = depositedAt;
+    p.status = PaymentStatus.PENDING;
+    return p;
+  }
+
+  public void submitDepositForm(String depositorName, String depositedAt) {
+    if (this.status != PaymentStatus.PENDING) {
+      throw new BusinessException(ErrorStatus.PAYMENT_NOT_PENDING);
     }
+    this.depositor = depositorName;
+    this.depositedAt = depositedAt;
+    this.status = PaymentStatus.REQUESTED;
+  }
 
-    public void submitDepositForm(String depositorName, String depositedAt) {
-        if (this.status != PaymentStatus.PENDING) {
-            throw new BusinessException(ErrorStatus.PAYMENT_NOT_PENDING);
-        }
-        this.depositor = depositorName;
-        this.depositedAt = depositedAt;
-        this.status = PaymentStatus.REQUESTED;
+  public void confirm(LocalDateTime confirmedAt) {
+    if (this.status != PaymentStatus.REQUESTED) {
+      throw new BusinessException(ErrorStatus.PAYMENT_NOT_REQUESTED);
     }
-
-    public void confirm(LocalDateTime confirmedAt) {
-        if (this.status != PaymentStatus.REQUESTED) {
-            throw new BusinessException(ErrorStatus.PAYMENT_NOT_REQUESTED);
-        }
-        this.status = PaymentStatus.CONFIRMED;
-        this.confirmedAt = confirmedAt;
-    }
+    this.status = PaymentStatus.CONFIRMED;
+    this.confirmedAt = confirmedAt;
+  }
 }

--- a/src/main/java/org/sopt/poti/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/sopt/poti/domain/payment/service/PaymentService.java
@@ -54,10 +54,11 @@ public class PaymentService {
       throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
     }
 
+    LocalDateTime confirmDateTime = LocalDateTime.now();
     // 입금 확인됨으로 처리
     order.confirmPayment();
     OrderConfirmResponse orderConfirmResponse = new OrderConfirmResponse(orderId,
-        order.getStatus(), LocalDateTime.now());
+        order.getStatus(), confirmDateTime);
 
     // 해당 분철글에 대해 'PAID'가 아닌 주문이 남아있는지 확인
     long allOrderPaid = orderService.countByGroupBuyPostIdAndStatusNot(groupBuyPost.getId(),


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #74 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
  1. 참여자 목록 조회 API 구현 (GET /api/v1/posts/{postId}/participants)
   - 총대(판매자)가 특정 분철글의 참여자 목록과 주문 상태를 조회하는 기능을 구현했습니다.
   - 상태별 정보 노출 제어: OrderStatus에 따라 노출되는 정보가 달라집니다.
       - RECRUITING: 기본 정보만 노출.
       - WAIT_PAY: 기본 정보만 노출.
       - WAIT_PAY_CHECK: 입금 정보(DepositInfo) 추가 노출.
       - PAID 이상: 배송 정보(ShippingInfo) 추가 노출.
   - DTO 구조: PostParticipantListResponse 내에 PostParticipantResponse 리스트를 포함하며, 내부적으로 PriceInfo, DepositInfo, ShippingInfo 객체를 가집니다.

  2. 버그 수정 및 안정성 개선
   - NPE 해결 (`createShippingInfo`): PAID 상태이지만 아직 운송장이 등록되지 않은(Delivery 엔티티가 없는) 경우, trackingNumber 조회 시 발생하던 NullPointerException을 해결했습니다. (delivery가 null이면
     trackingNumber도 null 반환)
   - N+1 방지: OrderRepository.findAllOrdersWithBasicInfo 메서드에서 Fetch Join을 사용하여 주문과 관련된 기본 정보(User, DeliveryMethod 등)를 한 번에 조회하도록 최적화했습니다.

## 📸 테스트 증명 (필수) 
<img width="936" height="1492" alt="image" src="https://github.com/user-attachments/assets/f05d5816-2c0b-4c35-bee6-b68bfa015d4c" />

<img width="748" height="1096" alt="image" src="https://github.com/user-attachments/assets/854027de-ba98-4512-ba4d-9c87d321a08b" />

<img width="956" height="1100" alt="image" src="https://github.com/user-attachments/assets/442ef47f-a313-4425-8153-ae5db37e2d20" />

<img width="800" height="968" alt="image" src="https://github.com/user-attachments/assets/43fd0123-9845-40d7-bcb6-9827fa7bf817" />

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
   - 조건부 응답: 클라이언트 요구사항에 맞춰 주문 상태에 따라 null을 반환하는 필드들이 있습니다. 프론트엔드에서 이를 처리하도록 협의되었습니다.
   - Helper Method: OrderService 내에 createPriceInfo, createDepositInfo 등의 헬퍼 메서드를 분리하여 비즈니스 로직의 가독성을 높였습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공동구매 참여자 목록 조회 추가 (주문 정보, 가격 구성, 입금 상태, 배송 정보 포함)

* **개선**
  * 판매자용 내 판매 내역 조회 엔드포인트 명칭 개선
  * 주문·결제·배송 관련 데이터 노출 및 처리 로직 개선으로 참여자 정보 제공 안정성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->