### PR TITLE
[REFACTOR] 분철글 참여자 다 찼을때 분철글 상태 변경

### DIFF
--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
@@ -151,4 +151,15 @@ public class GroupBuyPost extends BaseTimeEntity {
   public void updateStatus(GroupBuyPostStatus status) {
     this.status = status;
   }
+
+  //분철글 참여자 다 찼을때 분철글 상태 변경하는 메서드
+  public void increaseCurrentQuantity(int count) {
+    this.currentQuantity += count;
+
+    if (this.currentQuantity >= this.goalQuantity) {
+      this.currentQuantity = this.goalQuantity;
+      this.status = GroupBuyPostStatus.CLOSED;
+    }
+  }
+
 }

--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
@@ -24,6 +24,8 @@ import lombok.NoArgsConstructor;
 import org.sopt.poti.domain.artist.entity.Artist;
 import org.sopt.poti.domain.user.entity.User;
 import org.sopt.poti.global.entity.BaseTimeEntity;
+import org.sopt.poti.global.error.BusinessException;
+import org.sopt.poti.global.error.ErrorStatus;
 
 @Getter
 @Entity
@@ -155,7 +157,7 @@ public class GroupBuyPost extends BaseTimeEntity {
   //분철글 참여자 다 찼을때 분철글 상태 변경하는 메서드
   public void increaseCurrentQuantity(int count) {
     if (count <= 0) {
-      throw new IllegalArgumentException("count는 반드시 양수여야합니다.");
+      throw new BusinessException(ErrorStatus.GROUP_BUY_POST_INVALID_INCREASE_COUNT);
     }
     this.currentQuantity += count;
 

--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
@@ -154,6 +154,9 @@ public class GroupBuyPost extends BaseTimeEntity {
 
   //분철글 참여자 다 찼을때 분철글 상태 변경하는 메서드
   public void increaseCurrentQuantity(int count) {
+    if (count <= 0) {
+      throw new IllegalArgumentException("count는 반드시 양수여야합니다.");
+    }
     this.currentQuantity += count;
 
     if (this.currentQuantity >= this.goalQuantity) {

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderCreateService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderCreateService.java
@@ -109,6 +109,9 @@ public class OrderCreateService {
 
     orderItemRepository.saveAll(orderItems);
 
+    // 10 분철글 현재 인원 증가 및 분철 정원 다 차면 상태 변경(CLOSED)
+    post.increaseCurrentQuantity(orderItems.size());
+
     return new CreateOrderResponse(savedOrder.getId());
   }
 }

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderCreateService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderCreateService.java
@@ -110,8 +110,10 @@ public class OrderCreateService {
     orderItemRepository.saveAll(orderItems);
 
     // 10 분철글 현재 인원 증가 및 분철 정원 다 차면 상태 변경(CLOSED)
-    post.increaseCurrentQuantity(orderItems.size());
-
+    int totalCount = request.items().stream()
+        .mapToInt(OrderItemRequest::count)
+        .sum();
+    post.increaseCurrentQuantity(totalCount);
     return new CreateOrderResponse(savedOrder.getId());
   }
 }

--- a/src/main/java/org/sopt/poti/global/error/ErrorStatus.java
+++ b/src/main/java/org/sopt/poti/global/error/ErrorStatus.java
@@ -28,6 +28,7 @@ public enum ErrorStatus {
   DUPLICATE_ORDER_OPTION(40013, HttpStatus.BAD_REQUEST, "중복된 옵션은 한 주문에서 선택할 수 없습니다."),
   ORDER_NOT_PAID_OR_READY(40014, HttpStatus.BAD_REQUEST, "입금 완료 상태 또는 배송 대기 상태에서만 배송 중 처리가 가능합니다."),
   ORDER_EXISTS_SHIPPINGS(40015, HttpStatus.BAD_REQUEST, "이미 배송처리된 주문입니다."),
+  GROUP_BUY_POST_INVALID_INCREASE_COUNT(40016, HttpStatus.BAD_REQUEST, "증가 수량은 1 이상이어야 합니다."),
 
   /**
    * 401 Unauthorized


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #81 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 분철글 정원 다 차면 상태 COMPLETE로 변경하는 메서드를 추가했습니다.

## 📸 테스트 증명 (필수) 

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문 생성 시 주문 항목 합계만큼 그룹구매 참가 수량이 자동으로 증가하며, 목표 수량 도달 시 해당 게시물이 자동으로 종료됩니다.
  * 참가자 수 갱신은 주문 저장 직후 즉시 반영됩니다.

* **버그 수정 / 검증**
  * 증가 수량 입력에 대한 검증을 추가해 1 미만 요청에 대해 명확한 오류 응답을 반환하도록 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->