### PR TITLE
[REFACTOR] 아티스트 실시간 검색 응답값에 artistId 추가

### DIFF
--- a/src/main/java/org/sopt/poti/domain/artist/dto/response/ArtistTitlesResponse.java
+++ b/src/main/java/org/sopt/poti/domain/artist/dto/response/ArtistTitlesResponse.java
@@ -3,10 +3,14 @@ package org.sopt.poti.domain.artist.dto.response;
 import java.util.List;
 
 public record ArtistTitlesResponse(
-    List<String> titles
+    List<ArtistTitleDto> artists
 ) {
 
-  public static ArtistTitlesResponse of(List<String> titles) {
-    return new ArtistTitlesResponse(titles);
+  public record ArtistTitleDto(Long artistId, String name) {
+
+  }
+
+  public static ArtistTitlesResponse of(List<ArtistTitleDto> artists) {
+    return new ArtistTitlesResponse(artists);
   }
 }

--- a/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryCustom.java
+++ b/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryCustom.java
@@ -1,8 +1,9 @@
 package org.sopt.poti.domain.artist.repository;
 
 import java.util.List;
+import org.sopt.poti.domain.artist.dto.response.ArtistTitlesResponse;
 
 public interface ArtistRepositoryCustom {
 
-  List<String> findNamesByPrefix(String keyword, int limit);
+  List<ArtistTitlesResponse.ArtistTitleDto> findByPrefix(String keyword, int limit);
 }

--- a/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryImpl.java
@@ -1,8 +1,10 @@
 package org.sopt.poti.domain.artist.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.poti.domain.artist.dto.response.ArtistTitlesResponse.ArtistTitleDto;
 import org.sopt.poti.domain.artist.entity.QArtist;
 
 @RequiredArgsConstructor
@@ -11,11 +13,17 @@ public class ArtistRepositoryImpl implements ArtistRepositoryCustom {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public List<String> findNamesByPrefix(String keyword, int limit) {
+  public List<ArtistTitleDto> findByPrefix(String keyword, int limit) {
     QArtist artist = QArtist.artist;
 
     return queryFactory
-        .selectDistinct(artist.name)
+        .selectDistinct(
+            Projections.constructor(
+                ArtistTitleDto.class,
+                artist.id,
+                artist.name
+            )
+        )
         .from(artist)
         .where(artist.name.startsWithIgnoreCase(keyword))
         .orderBy(artist.name.asc())

--- a/src/main/java/org/sopt/poti/domain/artist/service/ArtistService.java
+++ b/src/main/java/org/sopt/poti/domain/artist/service/ArtistService.java
@@ -58,8 +58,9 @@ public class ArtistService {
       return ArtistTitlesResponse.of(List.of());
     }
 
-    List<String> titles = artistRepository.findNamesByPrefix(keyword.trim(), 5);
-    return ArtistTitlesResponse.of(titles);
+    List<ArtistTitlesResponse.ArtistTitleDto> artists =
+        artistRepository.findByPrefix(keyword.trim(), 5);
+    return ArtistTitlesResponse.of(artists);
   }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #87 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
**1. 아티스트 실시간 검색 응답 구조 개선**
- 기존 아티스트 자동완성 API가 아티스트 이름(String)만 반환하던 구조에서
 artistId + artistName을 함께 반환하도록 응답 DTO 구조를 변경

**2. ArtistTitlesResponse DTO 확장**
- List<String> titles → List<ArtistTitleDto> artists로 변경
- 내부에 ArtistTitleDto(Long artistId, String name) record 추가
- id 기반 후속 처리(선택 → 상세/등록)에 대응 가능하도록 개선

## 📸 테스트 증명 (필수) 
<img width="2353" height="974" alt="image" src="https://github.com/user-attachments/assets/98dbdb4f-be8a-499f-ac22-f70aa08328fe" />

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 아티스트 검색 결과에 아티스트 ID 정보 추가
  * 검색 응답에서 아티스트의 상세 정보(ID 및 이름) 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->