### PR TITLE
[FIX] 프로필 사진이 없으면 서비스 기본 프로필 이미지 삽입

### DIFF
--- a/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
@@ -37,6 +37,8 @@ public class AuthService {
   private final RefreshTokenRepository refreshTokenRepository;
   private final RedisTemplate<String, String> redisTemplate; // RedisTemplate 주입
 
+  private final static String DEFAULT_PROFILE_IMAGE = "https://poti-s3-bucket.s3.ap-northeast-2.amazonaws.com/users/img-basic-profile.png";
+
   @Value("${jwt.refresh-token-validity}")
   private long refreshTokenValidity;
 
@@ -83,7 +85,7 @@ public class AuthService {
           request.socialType(),
           email,
           nickname,
-          profileImageUrl,
+          profileImageUrl == null ? DEFAULT_PROFILE_IMAGE : profileImageUrl,
           null
       );
       userService.registerUser(user);

--- a/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/poti/domain/auth/service/AuthService.java
@@ -85,7 +85,9 @@ public class AuthService {
           request.socialType(),
           email,
           nickname,
-          profileImageUrl == null ? DEFAULT_PROFILE_IMAGE : profileImageUrl,
+          (profileImageUrl == null || profileImageUrl.isBlank())
+              ? DEFAULT_PROFILE_IMAGE
+              : profileImageUrl,
           null
       );
       userService.registerUser(user);


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #93 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 프로필 사진이 없으면 서비스 기본 프로필 이미지 삽입

## 📸 테스트 증명 (필수) 

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 소셜 로그인을 통해 가입하는 신규 사용자의 프로필 이미지가 누락되던 문제를 수정했습니다. 프로바이더로부터 이미지 정보가 없거나 비어 있을 경우 기본 프로필 이미지가 자동으로 설정되어 모든 신규 계정에 프로필 이미지가 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->