### PR TITLE
[FIX] 최애 아티스트가 null인 경우 홈 반환데이터 NPE 해결

### DIFF
--- a/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/repository/GroupBuyRepositoryImpl.java
@@ -3,7 +3,6 @@ package org.sopt.poti.domain.groupbuy.repository;
 import static org.sopt.poti.domain.artist.entity.QArtist.artist;
 import static org.sopt.poti.domain.groupbuy.entity.QGroupBuyOption.groupBuyOption;
 import static org.sopt.poti.domain.groupbuy.entity.QGroupBuyPost.groupBuyPost;
-import static org.sopt.poti.domain.groupbuy.entity.QItemImage.itemImage;
 import static org.sopt.poti.domain.order.entity.QOrderItem.orderItem;
 
 import com.querydsl.core.types.OrderSpecifier;
@@ -21,11 +20,8 @@ import org.sopt.poti.domain.feed.dto.request.FeedSearchCondition;
 import org.sopt.poti.domain.feed.dto.response.FeedGroupItem;
 import org.sopt.poti.domain.groupbuy.dto.request.GroupBuyListRequest;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
-import org.sopt.poti.domain.groupbuy.entity.QGroupBuyOption;
 import org.sopt.poti.domain.groupbuy.entity.QGroupBuyPost;
-import org.sopt.poti.domain.groupbuy.entity.QItemImage;
 import org.sopt.poti.domain.home.dto.response.HomeGroupBuyItem;
-import org.sopt.poti.domain.order.entity.QOrderItem;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -33,194 +29,195 @@ import org.springframework.data.domain.SliceImpl;
 @RequiredArgsConstructor
 public class GroupBuyRepositoryImpl implements GroupBuyRepositoryCustom {
 
-    private final JPAQueryFactory queryFactory;
+  private final JPAQueryFactory queryFactory;
 
-    @Override
-    public List<String> findTitlesByKeyword(Long artistId, String keyword, int limit) {
-        return queryFactory
-                .selectDistinct(groupBuyPost.title)
-                .from(groupBuyPost)
-                .where(
-                        groupBuyPost.artist.id.eq(artistId),
-                        groupBuyPost.title.contains(keyword)
-                )
-                .limit(limit)
-                .fetch();
+  @Override
+  public List<String> findTitlesByKeyword(Long artistId, String keyword, int limit) {
+    return queryFactory
+        .selectDistinct(groupBuyPost.title)
+        .from(groupBuyPost)
+        .where(
+            groupBuyPost.artist.id.eq(artistId),
+            groupBuyPost.title.contains(keyword)
+        )
+        .limit(limit)
+        .fetch();
+  }
+
+  @Override
+  public List<HomeGroupBuyItem> findPopularTitlesByArtist(Long artistId, int limit) {
+    QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+
+    return queryFactory
+        .select(Projections.constructor(HomeGroupBuyItem.class,
+            groupBuyPost.title,
+            artist.name,
+            JPAExpressions.select(subGroupBuyPost.representativeImageUrl)
+                .from(subGroupBuyPost)
+                .where(subGroupBuyPost.id.eq(
+                    JPAExpressions.select(subGroupBuyPost.id.max())
+                        .from(subGroupBuyPost)
+                        .where(subGroupBuyPost.title.eq(groupBuyPost.title)
+                            .and(artistIdEq(artistId, subGroupBuyPost))
+                            .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
+                )),
+            groupBuyPost.id.count(),
+            new CaseBuilder()
+                .when(groupBuyPost.id.count().goe(5L)).then("인기")
+                .otherwise("").as("tag")
+        ))
+        .from(groupBuyPost)
+        .join(groupBuyPost.artist, artist)
+        .where(artistIdEq(artistId, groupBuyPost))
+        .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
+        .orderBy(groupBuyPost.id.count().desc())
+        .limit(limit)
+        .fetch();
+  }
+
+  @Override
+  public List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long artistId, String sort,
+      int limit) {
+    QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+
+    return queryFactory
+        .select(Projections.constructor(HomeGroupBuyItem.class,
+            groupBuyPost.title,
+            artist.name,
+            JPAExpressions.select(subGroupBuyPost.representativeImageUrl)
+                .from(subGroupBuyPost)
+                .where(subGroupBuyPost.id.eq(
+                    JPAExpressions.select(subGroupBuyPost.id.max())
+                        .from(subGroupBuyPost)
+                        .where(subGroupBuyPost.title.eq(groupBuyPost.title)
+                            .and(artistIdNe(artistId, subGroupBuyPost))
+                            .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
+                )),
+            groupBuyPost.id.count(),
+            new CaseBuilder()
+                .when(groupBuyPost.id.count().goe(5L)).then("인기")
+                .otherwise("").as("tag")
+        ))
+        .from(groupBuyPost)
+        .join(groupBuyPost.artist, artist)
+        .where(artistIdNe(artistId, groupBuyPost))
+        .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
+        .orderBy(sortCondition(sort))
+        .limit(limit)
+        .fetch();
+  }
+
+  @Override
+  public Slice<FeedGroupItem> findFeedItems(FeedSearchCondition condition, Pageable pageable) {
+    QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+
+    List<FeedGroupItem> content = queryFactory
+        .select(Projections.constructor(FeedGroupItem.class,
+            artist.name,
+            JPAExpressions.select(subGroupBuyPost.representativeImageUrl)
+                .from(subGroupBuyPost)
+                .where(subGroupBuyPost.id.eq(
+                    JPAExpressions.select(subGroupBuyPost.id.max())
+                        .from(subGroupBuyPost)
+                        .where(subGroupBuyPost.title.eq(groupBuyPost.title)
+                            .and(artistIdEq(condition.artistId(), subGroupBuyPost))
+                            .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
+                )),
+            groupBuyPost.title,
+            groupBuyPost.id.count(),
+            new CaseBuilder()
+                .when(groupBuyPost.id.count().goe(5L)).then("인기")
+                .otherwise("").as("tag")
+        ))
+        .from(groupBuyPost)
+        .join(groupBuyPost.artist, artist)
+        .where(artistIdEq(condition.artistId(), groupBuyPost))
+        .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
+        .orderBy(sortCondition(condition.sort()))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize() + 1)
+        .fetch();
+
+    boolean hasNext = false;
+    if (content.size() > pageable.getPageSize()) {
+      content.remove(pageable.getPageSize());
+      hasNext = true;
     }
 
-    @Override
-    public List<HomeGroupBuyItem> findPopularTitlesByArtist(Long artistId, int limit) {
-        QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+    return new SliceImpl<>(content, pageable, hasNext);
+  }
 
-        return queryFactory
-                .select(Projections.constructor(HomeGroupBuyItem.class,
-                        groupBuyPost.title,
-                        artist.name,
-                        JPAExpressions.select(subGroupBuyPost.representativeImageUrl)
-                                .from(subGroupBuyPost)
-                                .where(subGroupBuyPost.id.eq(
-                                        JPAExpressions.select(subGroupBuyPost.id.max())
-                                                .from(subGroupBuyPost)
-                                                .where(subGroupBuyPost.title.eq(groupBuyPost.title)
-                                                        .and(subGroupBuyPost.artist.id.eq(artistId))
-                                                        .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
-                                )),
-                        groupBuyPost.id.count(),
-                        new CaseBuilder()
-                                .when(groupBuyPost.id.count().goe(5L)).then("인기")
-                                .otherwise("").as("tag")
-                ))
-                .from(groupBuyPost)
-                .join(groupBuyPost.artist, artist)
-                .where(groupBuyPost.artist.id.eq(artistId))
-                .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
-                .orderBy(groupBuyPost.id.count().desc())
-                .limit(limit)
-                .fetch();
+  @Override
+  public Slice<GroupBuyPost> findGroupBuyList(GroupBuyListRequest request, Pageable pageable) {
+    List<GroupBuyPost> content = queryFactory
+        .selectFrom(groupBuyPost)
+        .join(groupBuyPost.artist, artist).fetchJoin() // Artist Fetch Join
+        .join(groupBuyPost.leader).fetchJoin()         // Leader Fetch Join
+        .where(
+            groupBuyPost.title.eq(request.title()),
+            groupBuyPost.artist.id.eq(request.artistId()),
+            memberIdsIn(request.memberIds()) // 멤버 필터링
+        )
+        .orderBy(listSortCondition(request.sort()))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize() + 1)
+        .fetch();
+
+    boolean hasNext = false;
+    if (content.size() > pageable.getPageSize()) {
+      content.remove(pageable.getPageSize());
+      hasNext = true;
     }
 
-    @Override
-    public List<HomeGroupBuyItem> findPopularTitlesExcludingArtist(Long artistId, String sort, int limit) {
-        QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+    return new SliceImpl<>(content, pageable, hasNext);
+  }
 
-        return queryFactory
-                .select(Projections.constructor(HomeGroupBuyItem.class,
-                        groupBuyPost.title,
-                        artist.name,
-                        JPAExpressions.select(subGroupBuyPost.representativeImageUrl)
-                                .from(subGroupBuyPost)
-                                .where(subGroupBuyPost.id.eq(
-                                        JPAExpressions.select(subGroupBuyPost.id.max())
-                                                .from(subGroupBuyPost)
-                                                .where(subGroupBuyPost.title.eq(groupBuyPost.title)
-                                                        .and(artistIdNe(artistId, subGroupBuyPost))
-                                                        .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
-                                )),
-                        groupBuyPost.id.count(),
-                        new CaseBuilder()
-                                .when(groupBuyPost.id.count().goe(5L)).then("인기")
-                                .otherwise("").as("tag")
-                ))
-                .from(groupBuyPost)
-                .join(groupBuyPost.artist, artist)
-                .where(artistIdNe(artistId, groupBuyPost))
-                .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
-                .orderBy(sortCondition(sort))
-                .limit(limit)
-                .fetch();
+  // 멤버 필터링: 선택한 멤버들이 '남아있는(주문되지 않은)' 상태여야 함
+  private BooleanExpression memberIdsIn(List<Long> memberIds) {
+    if (memberIds == null || memberIds.isEmpty()) {
+      return null;
     }
 
-    @Override
-    public Slice<FeedGroupItem> findFeedItems(FeedSearchCondition condition, Pageable pageable) {
-        QGroupBuyPost subGroupBuyPost = new QGroupBuyPost("subGroupBuyPost");
+    // 서브쿼리: 이 게시글의 옵션 중에, memberId가 일치하면서, OrderItem이 없는(주문 안 된) 옵션이 존재하는가?
+    return JPAExpressions.selectOne()
+        .from(groupBuyOption)
+        .leftJoin(orderItem).on(orderItem.groupBuyOption.eq(groupBuyOption))
+        .where(
+            groupBuyOption.groupBuyPost.eq(groupBuyPost),
+            groupBuyOption.member.id.in(memberIds),
+            orderItem.isNull() // 주문 내역이 없어야 함 (남은 멤버)
+        )
+        .exists();
+  }
 
-        List<FeedGroupItem> content = queryFactory
-                .select(Projections.constructor(FeedGroupItem.class,
-                        artist.name,
-                        JPAExpressions.select(subGroupBuyPost.representativeImageUrl)
-                                .from(subGroupBuyPost)
-                                .where(subGroupBuyPost.id.eq(
-                                        JPAExpressions.select(subGroupBuyPost.id.max())
-                                                .from(subGroupBuyPost)
-                                                .where(subGroupBuyPost.title.eq(groupBuyPost.title)
-                                                        .and(artistIdEq(condition.artistId(), subGroupBuyPost))
-                                                        .and(subGroupBuyPost.artist.id.eq(groupBuyPost.artist.id)))
-                                )),
-                        groupBuyPost.title,
-                        groupBuyPost.id.count(),
-                        new CaseBuilder()
-                                .when(groupBuyPost.id.count().goe(5L)).then("인기")
-                                .otherwise("").as("tag")
-                ))
-                .from(groupBuyPost)
-                .join(groupBuyPost.artist, artist)
-                .where(artistIdEq(condition.artistId(), groupBuyPost))
-                .groupBy(groupBuyPost.title, artist.name, groupBuyPost.artist.id)
-                .orderBy(sortCondition(condition.sort()))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
-
-        boolean hasNext = false;
-        if (content.size() > pageable.getPageSize()) {
-            content.remove(pageable.getPageSize());
-            hasNext = true;
-        }
-
-        return new SliceImpl<>(content, pageable, hasNext);
+  private OrderSpecifier<?> listSortCondition(String sort) {
+    if ("DEADLINE".equalsIgnoreCase(sort)) {
+      return groupBuyPost.recruitDeadline.asc();
     }
-
-    @Override
-    public Slice<GroupBuyPost> findGroupBuyList(GroupBuyListRequest request, Pageable pageable) {
-        List<GroupBuyPost> content = queryFactory
-                .selectFrom(groupBuyPost)
-                .join(groupBuyPost.artist, artist).fetchJoin() // Artist Fetch Join
-                .join(groupBuyPost.leader).fetchJoin()         // Leader Fetch Join
-                .where(
-                        groupBuyPost.title.eq(request.title()),
-                        groupBuyPost.artist.id.eq(request.artistId()),
-                        memberIdsIn(request.memberIds()) // 멤버 필터링
-                )
-                .orderBy(listSortCondition(request.sort()))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1)
-                .fetch();
-
-        boolean hasNext = false;
-        if (content.size() > pageable.getPageSize()) {
-            content.remove(pageable.getPageSize());
-            hasNext = true;
-        }
-
-        return new SliceImpl<>(content, pageable, hasNext);
+    if ("RATING".equalsIgnoreCase(sort)) {
+      return groupBuyPost.leader.ratingAvg.desc();
     }
+    // 기본값: 최신순
+    return groupBuyPost.createdAt.desc();
+  }
 
-    // 멤버 필터링: 선택한 멤버들이 '남아있는(주문되지 않은)' 상태여야 함
-    private BooleanExpression memberIdsIn(List<Long> memberIds) {
-        if (memberIds == null || memberIds.isEmpty()) {
-            return null;
-        }
+  private BooleanExpression artistIdNe(Long artistId, QGroupBuyPost post) {
+    return artistId != null ? post.artist.id.ne(artistId) : null;
+  }
 
-        // 서브쿼리: 이 게시글의 옵션 중에, memberId가 일치하면서, OrderItem이 없는(주문 안 된) 옵션이 존재하는가?
-        return JPAExpressions.selectOne()
-                .from(groupBuyOption)
-                .leftJoin(orderItem).on(orderItem.groupBuyOption.eq(groupBuyOption))
-                .where(
-                        groupBuyOption.groupBuyPost.eq(groupBuyPost),
-                        groupBuyOption.member.id.in(memberIds),
-                        orderItem.isNull() // 주문 내역이 없어야 함 (남은 멤버)
-                )
-                .exists();
+  private BooleanExpression artistIdEq(Long artistId, QGroupBuyPost post) {
+    return artistId != null ? post.artist.id.eq(artistId) : null;
+  }
+
+  private OrderSpecifier<?> sortCondition(String sort) {
+    if ("HOT".equalsIgnoreCase(sort)) {
+      return groupBuyPost.id.count().desc();
     }
-
-    private OrderSpecifier<?> listSortCondition(String sort) {
-        if ("DEADLINE".equalsIgnoreCase(sort)) {
-            return groupBuyPost.recruitDeadline.asc();
-        }
-        if ("RATING".equalsIgnoreCase(sort)) {
-            return groupBuyPost.leader.ratingAvg.desc();
-        }
-        // 기본값: 최신순
-        return groupBuyPost.createdAt.desc();
+    if ("RANDOM".equalsIgnoreCase(sort)) {
+      LocalDate today = LocalDate.now();
+      int seed = Integer.parseInt(today.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
+      return Expressions.numberTemplate(Double.class, "function('rand', {0})", seed).asc();
     }
-
-    private BooleanExpression artistIdNe(Long artistId, QGroupBuyPost post) {
-        return artistId != null ? post.artist.id.ne(artistId) : null;
-    }
-
-    private BooleanExpression artistIdEq(Long artistId, QGroupBuyPost post) {
-        return artistId != null ? post.artist.id.eq(artistId) : null;
-    }
-
-    private OrderSpecifier<?> sortCondition(String sort) {
-        if ("HOT".equalsIgnoreCase(sort)) {
-            return groupBuyPost.id.count().desc();
-        }
-        if ("RANDOM".equalsIgnoreCase(sort)) {
-            LocalDate today = LocalDate.now();
-            int seed = Integer.parseInt(today.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
-            return Expressions.numberTemplate(Double.class, "function('rand', {0})", seed).asc();
-        }
-        return groupBuyPost.createdAt.max().desc();
-    }
+    return groupBuyPost.createdAt.max().desc();
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #95 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 최애 아티스트가 null인 경우 홈 반환데이터 NPE 해결

## 📸 테스트 증명 (필수) 
<img width="996" height="1434" alt="image" src="https://github.com/user-attachments/assets/416d392e-3d52-487e-8777-59a1b16ee975" />


## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
QueryDSL의 `where` 절 동작 방식:
 - QueryDSL의 where 절은 null인 조건을 무시합니다.

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 인기 타이틀 추천 및 피드 기능 추가
  * 고급 검색, 필터링, 정렬 옵션 확대

* **개선 사항**
  * 그룹 구매 목록 조회 성능 및 유연성 강화
  * 페이지네이션 지원으로 대량 데이터 처리 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->