### PR TITLE
[REFACTOR] 아티스트 실시간검색 첫글자 기준 제한 해제

### DIFF
--- a/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryCustom.java
+++ b/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryCustom.java
@@ -5,5 +5,5 @@ import org.sopt.poti.domain.artist.dto.response.ArtistTitlesResponse;
 
 public interface ArtistRepositoryCustom {
 
-  List<ArtistTitlesResponse.ArtistTitleDto> findByPrefix(String keyword, int limit);
+  List<ArtistTitlesResponse.ArtistTitleDto> findByKeyword(String keyword, int limit);
 }

--- a/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryImpl.java
+++ b/src/main/java/org/sopt/poti/domain/artist/repository/ArtistRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.sopt.poti.domain.artist.repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +14,7 @@ public class ArtistRepositoryImpl implements ArtistRepositoryCustom {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public List<ArtistTitleDto> findByPrefix(String keyword, int limit) {
+  public List<ArtistTitleDto> findByKeyword(String keyword, int limit) {
     QArtist artist = QArtist.artist;
 
     return queryFactory
@@ -25,9 +26,18 @@ public class ArtistRepositoryImpl implements ArtistRepositoryCustom {
             )
         )
         .from(artist)
-        .where(artist.name.startsWithIgnoreCase(keyword))
-        .orderBy(artist.name.asc())
+        .where(
+            artist.name.containsIgnoreCase(keyword)
+        )
+        .orderBy(
+            new CaseBuilder()
+                .when(artist.name.startsWithIgnoreCase(keyword)).then(0)
+                .otherwise(1)
+                .asc(),
+            artist.name.asc()
+        )
         .limit(limit)
         .fetch();
   }
+
 }

--- a/src/main/java/org/sopt/poti/domain/artist/service/ArtistService.java
+++ b/src/main/java/org/sopt/poti/domain/artist/service/ArtistService.java
@@ -59,7 +59,8 @@ public class ArtistService {
     }
 
     List<ArtistTitlesResponse.ArtistTitleDto> artists =
-        artistRepository.findByPrefix(keyword.trim(), 5);
+        artistRepository.findByKeyword(keyword.trim(), 5);
+
     return ArtistTitlesResponse.of(artists);
   }
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #135 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- prefix기준 검색 말고, prefix가 위에 뜨고/이름에 그 글자가 포함된 그룹은 아래에 뜨도록 수정했습니다.

## 📸 테스트 증명 (필수) 
- N검색시
<img width="1070" height="1119" alt="image" src="https://github.com/user-attachments/assets/4d11fe72-61a0-4448-978e-757bf429bbb0" />


## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 집에 얼른 와  . . .

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 아티스트 검색 알고리즘이 개선되었습니다. 이제 키워드를 포함하는 모든 아티스트를 검색할 수 있어 검색 범위가 확대됩니다.
  * 검색 결과 정렬이 최적화되었습니다. 키워드로 시작하는 아티스트가 우선 표시된 후, 나머지 결과가 이름순으로 정렬됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->