### PR TITLE
[FIX] 분철글 상태 자동 변경 로직 오류 수정 (주문 상태 혼재 시 미반영)

### DIFF
--- a/src/main/java/org/sopt/poti/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/sopt/poti/domain/order/repository/OrderRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.poti.domain.order.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.sopt.poti.domain.order.entity.Order;
@@ -42,4 +43,7 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
         WHERE o.id = :orderId
       """)
   Optional<Order> findWithDetailsById(@Param("orderId") Long orderId);
+
+  // 특정 게시글에서, 주어진 상태 목록에 해당하는 주문이 몇 개인지 조회
+  long countByGroupBuyPostIdAndStatusIn(Long postId, Collection<OrderStatus> statuses);
 }

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
@@ -99,6 +99,16 @@ public class OrderService {
       throw new BusinessException(ErrorStatus.ORDER_EXISTS_SHIPPINGS);
     }
 
+    long notShippedCount = orderRepository.countByGroupBuyPostIdAndStatusIn(
+        groupBuyPost.getId(),
+        List.of(OrderStatus.WAIT_PAY, OrderStatus.WAIT_PAY_CHECK, OrderStatus.PAID,
+            OrderStatus.READY)
+    );
+
+    if (notShippedCount == 0) { // 모두 배송 시작(SHIPPED) 이상
+      groupBuyPost.updateStatus(GroupBuyPostStatus.SHIPPING);
+    }
+
     LocalDateTime shippedAt = LocalDateTime.now();
 
     Delivery delivery = Delivery.builder()
@@ -305,5 +315,12 @@ public class OrderService {
 
   public Optional<Order> findWithDetailsById(Long orderId) {
     return orderRepository.findWithDetailsById(orderId);
+  }
+
+  public long countByGroupBuyPostIdAndStatusIn(Long groupBuyPostId, List<OrderStatus> statusList) {
+    return orderRepository.countByGroupBuyPostIdAndStatusIn(
+        groupBuyPostId,
+        statusList
+    );
   }
 }

--- a/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
+++ b/src/main/java/org/sopt/poti/domain/order/service/OrderService.java
@@ -99,16 +99,6 @@ public class OrderService {
       throw new BusinessException(ErrorStatus.ORDER_EXISTS_SHIPPINGS);
     }
 
-    long notShippedCount = orderRepository.countByGroupBuyPostIdAndStatusIn(
-        groupBuyPost.getId(),
-        List.of(OrderStatus.WAIT_PAY, OrderStatus.WAIT_PAY_CHECK, OrderStatus.PAID,
-            OrderStatus.READY)
-    );
-
-    if (notShippedCount == 0) { // 모두 배송 시작(SHIPPED) 이상
-      groupBuyPost.updateStatus(GroupBuyPostStatus.SHIPPING);
-    }
-
     LocalDateTime shippedAt = LocalDateTime.now();
 
     Delivery delivery = Delivery.builder()
@@ -121,6 +111,16 @@ public class OrderService {
     deliveryService.saveDelivery(delivery);
     order.startDelivery();
 
+    long notShippedCount = orderRepository.countByGroupBuyPostIdAndStatusIn(
+        groupBuyPost.getId(),
+        List.of(OrderStatus.WAIT_PAY, OrderStatus.WAIT_PAY_CHECK, OrderStatus.PAID,
+            OrderStatus.READY)
+    );
+
+    if (notShippedCount == 0) { // 모두 배송 시작(SHIPPED) 이상
+      groupBuyPost.updateStatus(GroupBuyPostStatus.SHIPPING);
+    }
+    
     return new StartDeliveryResponse(orderId, order.getStatus(),
         startDeliveryRequest.trackingNumber(), shippedAt);
   }

--- a/src/main/java/org/sopt/poti/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/sopt/poti/domain/payment/service/PaymentService.java
@@ -1,6 +1,7 @@
 package org.sopt.poti.domain.payment.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPost;
 import org.sopt.poti.domain.groupbuy.entity.GroupBuyPostStatus;
@@ -72,12 +73,11 @@ public class PaymentService {
     OrderConfirmResponse orderConfirmResponse = new OrderConfirmResponse(orderId,
         order.getStatus(), confirmDateTime);
 
-    // 해당 분철글에 대해 'PAID'가 아닌 주문이 남아있는지 확인
-    long allOrderPaid = orderService.countByGroupBuyPostIdAndStatusNot(groupBuyPost.getId(),
-        OrderStatus.PAID);
-
-    //  미입금 주문이 없다면(모두 PAID라면) 분철글 상태 변경
-    if (!(allOrderPaid > 0)) {
+    long unpaidCount = orderService.countByGroupBuyPostIdAndStatusIn(
+        groupBuyPost.getId(),
+        List.of(OrderStatus.WAIT_PAY, OrderStatus.WAIT_PAY_CHECK)
+    );
+    if (unpaidCount == 0) { // 모두 입금 완료(PAID) 이상
       groupBuyPost.updateStatus(GroupBuyPostStatus.PAYMENT_DONE);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #140 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 분철글 상태 자동 변경 로직 오류 수정 (주문 상태 혼재 시 미반영)

## 📸 테스트 증명 (필수) 

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 미배송 주문 집계를 도입하여 모든 미배송 주문이 처리되면 그룹 구매 게시물 상태가 자동으로 "배송 중"으로 전환됩니다.
  * 결제 상태 확인이 다중 상태 기반으로 강화되어 미결제/미확인 주문을 더 정확하게 감지하고, 모든 결제가 완료되면 게시물 상태를 "결제 완료"로 업데이트합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->