### PR TITLE
[REFACTOR] 구매자 - 참여 상세 정보 상태값 OrderStatus로 변경

### DIFF
--- a/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/entity/GroupBuyPost.java
@@ -187,9 +187,6 @@ public class GroupBuyPost extends BaseTimeEntity {
 
   // 분철글 상태 변경 메서드 (참여자 모두의 OrderStatus가 배송완료일때, GroupBuyPostStatus도 배송완료로 변경)
   public void completePostDelivery() {
-    if (this.status != GroupBuyPostStatus.SHIPPING) {
-      throw new BusinessException(ErrorStatus.POST_NOT_SHIPPING);
-    }
     this.status = GroupBuyPostStatus.DELIVERED;
   }
 

--- a/src/main/java/org/sopt/poti/domain/order/entity/OrderStatus.java
+++ b/src/main/java/org/sopt/poti/domain/order/entity/OrderStatus.java
@@ -1,6 +1,9 @@
 package org.sopt.poti.domain.order.entity;
 
 public enum OrderStatus {
+  //데모데이를 위한 상태값(이후 리펙토링 필요)
+  RECRUITING, //각각의 주문에 대한 모집중 상태값
+  
   WAIT_PAY, // 입금 대기
   WAIT_PAY_CHECK, //입금 확인 대기
   PAID, //입금 완료

--- a/src/main/java/org/sopt/poti/domain/participation/dto/response/ParticipationDetailResponse.java
+++ b/src/main/java/org/sopt/poti/domain/participation/dto/response/ParticipationDetailResponse.java
@@ -8,8 +8,7 @@ public record ParticipationDetailResponse(
     String artistName,
     String title,
 
-    String postStatus,    // GroupBuyPostStatus
-    String orderStatus,   // OrderStatus
+    String status,//OrderStatus 기반 상단 Status (GroupBuyPostStatus같이)
     String statusMessage, // 상단 진행 멘트
 
     List<MemberPaymentDto> memberPayments,

--- a/src/main/java/org/sopt/poti/domain/participation/service/ParticipationDetailService.java
+++ b/src/main/java/org/sopt/poti/domain/participation/service/ParticipationDetailService.java
@@ -40,23 +40,22 @@ public class ParticipationDetailService {
 
     GroupBuyPost post = order.getGroupBuyPost();
     OrderStatus orderStatus = order.getStatus();
-    GroupBuyPostStatus postStatus = post.getStatus();
 
-    String postStatusValue = (postStatus != null) ? postStatus.name() : null;
-    String orderStatusValue = (orderStatus != null) ? orderStatus.name() : null;
+    // 상단부 상태값 -> OrderStatus 기준으로 가공
+    String topStatus = mapTopStatus(orderStatus);
 
     // 상단 진행 멘트
-    String statusMessage = determineStatusMessage(postStatus, orderStatus);
+    String statusMessage = determineStatusMessage(orderStatus);
 
     // 1. 계좌 및 입금기한 노출 제어
+    // 전부 OrderStatus 기준으로 제어
     boolean showPaymentDetails =
-        (postStatus != GroupBuyPostStatus.RECRUITING
-            && (orderStatus == OrderStatus.WAIT_PAY || orderStatus == OrderStatus.WAIT_PAY_CHECK));
+        (orderStatus == OrderStatus.WAIT_PAY || orderStatus == OrderStatus.WAIT_PAY_CHECK);
 
     String bank = showPaymentDetails ? post.getBankName() : null;
     String accountNumber = showPaymentDetails ? post.getAccountNumber() : null;
 
-    // 입금 마감 기한
+    // 입금 마감 기한 (24시간)
     String depositDeadline = null;
     if (showPaymentDetails && post.getRecruitDeadline() != null) {
       LocalDateTime deadlineAt = post.getRecruitDeadline().atTime(LocalTime.of(23, 59));
@@ -67,7 +66,7 @@ public class ParticipationDetailService {
     Delivery delivery = deliveryService.findTopByOrder_IdOrderByIdDesc(order.getId())
         .orElse(null);
 
-    // 배송 상태에 따른 정보값
+    // 배송 상태에 따른 정보값(OrderStatus 기준)
     boolean isShippingActive = (orderStatus == OrderStatus.SHIPPED);
 
     String carrier = isShippingActive
@@ -78,13 +77,17 @@ public class ParticipationDetailService {
         ? (delivery != null ? delivery.getTrackingNumber() : null)
         : null;
 
+    String orderStatusValue = (orderStatus != null) ? orderStatus.name() : null;
+
     return new ParticipationDetailResponse(
         order.getId(),
         post.getRepresentativeImageUrl(),
         post.getArtist().getName(),
         post.getTitle(),
-        postStatusValue,
-        orderStatusValue,
+
+        topStatus,
+        // 상단 상태값 (RECRUITING / CLOSED / PAYMENT_DONE / SHIPPING / DELIVERED)
+        //-> OrderStatus 기준인데 GroupBuyPostStatus처럼 바꿔줌
         statusMessage,
 
         getMemberPaymentList(order),
@@ -110,9 +113,34 @@ public class ParticipationDetailService {
         )
     );
   }
-  
-  private String determineStatusMessage(GroupBuyPostStatus postStatus, OrderStatus orderStatus) {
-    if (postStatus == GroupBuyPostStatus.RECRUITING) {
+
+  private List<ParticipationDetailResponse.MemberPaymentDto> getMemberPaymentList(Order order) {
+    return order.getOrderItems().stream()
+        .map(item -> new ParticipationDetailResponse.MemberPaymentDto(
+            item.getGroupBuyOption().getMember().getName(),
+            item.getItemAmount()
+        ))
+        .toList();
+  }
+
+  // OrderStatus 기반으로 GroupBuyPostStatus 값 재사용 (상단 상태값 전용)
+  private String mapTopStatus(OrderStatus orderStatus) {
+    if (orderStatus == null) {
+      return null;
+    }
+
+    return switch (orderStatus) {
+      case RECRUITING -> GroupBuyPostStatus.RECRUITING.name();
+      case WAIT_PAY, WAIT_PAY_CHECK -> GroupBuyPostStatus.CLOSED.name();
+      case PAID, READY -> GroupBuyPostStatus.PAYMENT_DONE.name();
+      case SHIPPED -> GroupBuyPostStatus.SHIPPING.name();
+      case DELIVERED -> GroupBuyPostStatus.DELIVERED.name();
+    };
+  }
+
+  // 상단 진행 멘트 (OrderStatus 기반)
+  private String determineStatusMessage(OrderStatus orderStatus) {
+    if (orderStatus == OrderStatus.RECRUITING) {
       return "다른 참여자들을 기다리고 있어요";
     }
     return switch (orderStatus) {
@@ -123,14 +151,5 @@ public class ParticipationDetailService {
       case DELIVERED -> "거래가 종료되었어요";
       default -> null;
     };
-  }
-
-  private List<ParticipationDetailResponse.MemberPaymentDto> getMemberPaymentList(Order order) {
-    return order.getOrderItems().stream()
-        .map(item -> new ParticipationDetailResponse.MemberPaymentDto(
-            item.getGroupBuyOption().getMember().getName(),
-            item.getItemAmount()
-        ))
-        .toList();
   }
 }

--- a/src/main/java/org/sopt/poti/domain/participation/service/ParticipationService.java
+++ b/src/main/java/org/sopt/poti/domain/participation/service/ParticipationService.java
@@ -61,6 +61,12 @@ public class ParticipationService {
       throw new BusinessException(ErrorStatus.FORBIDDEN_USER);
     }
 
+    // OrderStatus기준 배송중(SHIPPED)일 때만 배송완료 확정 가능
+    if (order.getStatus() != OrderStatus.SHIPPED) {
+      throw new BusinessException(
+          ErrorStatus.ORDER_NOT_SHIPPED);
+    }
+
     // 1 내 주문 배송완료 처리 (OrderStatus)
     order.completeDelivery();
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #138 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
**1. 배송 완료 PATCH 기준을 OrderStatus 기준으로 명확히 분리**

- 기존: 분철글(GroupBuyPostStatus) 상태를 기준으로 배송 완료 가능 여부를 판단

- 변경: 개별 주문(OrderStatus)이 SHIPPED → DELIVERED로 변경되는지를 기준으로 PATCH 처리
-  배송 완료 처리는 항상 Order 단위로만 수행하도록 정리

**2. 분철글 상태는 “결과 상태”로만 동기화**

- 참여자 모두의 OrderStatus가 DELIVERED가 되면 해당 분철글의 GroupBuyPostStatus를 DELIVERED로 변경
- 분철글 상태가 중간 단계(SHIPPING)를 반드시 거치도록 강제하지 않음

**3. 분철글 배송 완료 판단 로직 정리**
-기존 countUnpaidOrders 쿼리를 재사용하여 특정 상태가 아닌 주문이 남아있는지 확인
- 마지막 주문까지 DELIVERED 처리되면 분철글도 함께 DELIVERED 처리

## 📸 테스트 증명 (필수) 
- 로컬 테스트 완료 했습니다 !

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 배송 확인 시 상태 검증 강화 — 배송된 주문만 배송 완료로 확인 가능
  * 특정 경로에서 배송 상태가 부적절하게 변경되는 문제 수정

* **개선사항**
  * 참여 화면의 상태 표시를 단일 필드로 통합하여 표시 간소화
  * 결제 정보 노출 조건 및 상태 메시지 로직 정비
  * 입금 기한 표시 형식을 "yyyy-MM-dd HH:mm 까지"로 명확화
* **기타**
  * 데모용 신규 주문 상태(RECRUITING) 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->