### PR TITLE
[FIX] 분철별 팟 기본으로 마감임박순 설정

### DIFF
--- a/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyListRequest.java
+++ b/src/main/java/org/sopt/poti/domain/groupbuy/dto/request/GroupBuyListRequest.java
@@ -25,5 +25,10 @@ public record GroupBuyListRequest(
     if (title != null) {
       title = title.trim(); // 여기서 앞뒤 공백 제거
     }
+
+    // Sort 디폴트 값 설정 (null이거나 빈 문자열이면 DEADLINE)
+    if (sort == null || sort.isBlank()) {
+      sort = "DEADLINE";
+    }
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #176 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 분철별 팟 기본으로 마감임박순 설정

## 📸 테스트 증명 (필수) 

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [ ] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [ ] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [ ] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [ ] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 그룹 구매 목록 조회 시 정렬 옵션의 기본값이 자동으로 설정되도록 개선했습니다. 정렬 옵션이 지정되지 않은 경우 마감 날짜 기준으로 정렬됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->