### PR TITLE
[FIX] 휴대폰 번호 검증 어노테이션 추가

### DIFF
--- a/src/main/java/org/sopt/poti/domain/order/entity/DeliveryInfo.java
+++ b/src/main/java/org/sopt/poti/domain/order/entity/DeliveryInfo.java
@@ -2,6 +2,7 @@ package org.sopt.poti.domain.order.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,7 +23,8 @@ public class DeliveryInfo {
   private String addressLine;
 
   @Column(length = 20)
-  @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 양식에 맞지 않습니다.")
+  @NotBlank(message = "휴대폰 번호는 필수입니다.")
+  @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 양식에 맞지 않습니다.")
   private String phone;
 
   public DeliveryInfo(

--- a/src/main/java/org/sopt/poti/domain/order/entity/DeliveryInfo.java
+++ b/src/main/java/org/sopt/poti/domain/order/entity/DeliveryInfo.java
@@ -2,6 +2,7 @@ package org.sopt.poti.domain.order.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,27 +12,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DeliveryInfo {
 
-    @Column(name = "receiver_name", length = 50)
-    private String receiverName;
+  @Column(name = "receiver_name", length = 50)
+  private String receiverName;
 
-    @Column(length = 10)
-    private String zipcode;
+  @Column(length = 10)
+  private String zipcode;
 
-    @Column(name = "address_line", length = 255)
-    private String addressLine;
+  @Column(name = "address_line", length = 255)
+  private String addressLine;
 
-    @Column(length = 20)
-    private String phone;
+  @Column(length = 20)
+  @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 양식에 맞지 않습니다.")
+  private String phone;
 
-    public DeliveryInfo(
-            String receiverName,
-            String zipcode,
-            String addressLine,
-            String phone
-    ) {
-        this.receiverName = receiverName;
-        this.zipcode = zipcode;
-        this.addressLine = addressLine;
-        this.phone = phone;
-    }
+  public DeliveryInfo(
+      String receiverName,
+      String zipcode,
+      String addressLine,
+      String phone
+  ) {
+    this.receiverName = receiverName;
+    this.zipcode = zipcode;
+    this.addressLine = addressLine;
+    this.phone = phone;
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #148 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 구매자 구입 폼 제출시 작성하는 휴대폰번호에 대한 양식 검증 어노테이션을 추가했습니다.

## 📸 테스트 증명 (필수) 

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 배송 정보의 휴대폰 번호 입력 검증이 강화되었습니다. 이제 사용자는 지정된 한국 휴대폰 형식(예: 010-1234-5678 등)으로만 입력할 수 있으며, 형식이 맞지 않으면 저장되지 않아 데이터 정확성이 향상됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->