### PR TITLE
[FIX] 구매자 - 참여 상세 정보 모집완료 상태 분철글 상태를 따르게 수정

### DIFF
--- a/src/main/java/org/sopt/poti/domain/participation/service/ParticipationDetailService.java
+++ b/src/main/java/org/sopt/poti/domain/participation/service/ParticipationDetailService.java
@@ -41,11 +41,11 @@ public class ParticipationDetailService {
     GroupBuyPost post = order.getGroupBuyPost();
     OrderStatus orderStatus = order.getStatus();
 
-    // 상단부 상태값 -> OrderStatus 기준으로 가공
-    String topStatus = mapTopStatus(orderStatus);
+    // 상단부 상태값 -> GroupBuyPostStatus가 Recruting일때는 이를 반영 -> CLOSED 이후에는 OrderStatus 기준으로 가공
+    String topStatus = mapTopStatus(post.getStatus(), orderStatus);
 
     // 상단 진행 멘트
-    String statusMessage = determineStatusMessage(orderStatus);
+    String statusMessage = determineStatusMessage(post.getStatus(), orderStatus);
 
     // 1. 계좌 및 입금기한 노출 제어
     // 전부 OrderStatus 기준으로 제어
@@ -125,8 +125,15 @@ public class ParticipationDetailService {
         .toList();
   }
 
-  // OrderStatus 기반으로 GroupBuyPostStatus 값 재사용 (상단 상태값 전용)
-  private String mapTopStatus(OrderStatus orderStatus) {
+  // GroupBuyPostStatus 우선 반영(RECRUTING까지) -> CLOSED 이후에는 OrderStatus 기준
+  private String mapTopStatus(GroupBuyPostStatus groupBuyPostStatus, OrderStatus orderStatus) {
+
+    // 1 분철글이 모집중이면 무조건 RECRUITING 고정
+    if (groupBuyPostStatus == GroupBuyPostStatus.RECRUITING) {
+      return GroupBuyPostStatus.RECRUITING.name();
+    }
+
+    // 2 분철글 모집 마감(CLOSED)부터는 OrderStatus 기준으로 기존 매핑
     if (orderStatus == null) {
       return null;
     }
@@ -140,11 +147,18 @@ public class ParticipationDetailService {
     };
   }
 
-  // 상단 진행 멘트 (OrderStatus 기반)
-  private String determineStatusMessage(OrderStatus orderStatus) {
-    if (orderStatus == OrderStatus.RECRUITING) {
+
+  // 상단 진행 멘트 (OrderStatus 기반, RECRUTING시에는 공구글 우선)
+  private String determineStatusMessage(
+      GroupBuyPostStatus postStatus,
+      OrderStatus orderStatus
+  ) {
+    // 1 모집중이면 무조건 모집중 멘트를 띄움
+    if (postStatus == GroupBuyPostStatus.RECRUITING) {
       return "다른 참여자들을 기다리고 있어요";
     }
+
+    // 2 모집 마감 이후부터는 OrderStatus 기준으로 멘트를 띄움
     return switch (orderStatus) {
       case WAIT_PAY -> "지금 입금해주세요";
       case WAIT_PAY_CHECK -> "모집자가 입금 내역을 확인하고 있어요";


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #192 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 

## 📸 테스트 증명 (필수) 
- 멤버 2개인 글에 주문 1개 넣었을때
<img width="1070" height="1298" alt="image" src="https://github.com/user-attachments/assets/448b87ca-a250-40cb-aa94-3776c8f16d6b" />

- 주문 2개 다 넣었을때
<img width="1005" height="1306" alt="image" src="https://github.com/user-attachments/assets/cb721f10-6517-49b9-8125-898058417a01" />

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 참여 상세 정보의 상태 표시 우선순위를 개선하여 모집 중 상태가 적절히 강조됩니다.
  * 주문 상태에 따른 상태 메시지 표시 로직을 확장하여 더 정확한 상태 정보를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->