### PR TITLE
[FIX] 구매자 - 참여 리스트 모집완료 상태 분철글 상태를 따르게

### DIFF
--- a/src/main/java/org/sopt/poti/domain/participation/service/ParticipationService.java
+++ b/src/main/java/org/sopt/poti/domain/participation/service/ParticipationService.java
@@ -74,7 +74,7 @@ public class ParticipationService {
     Long leaderUserId = order.getGroupBuyPost().getLeader().getId();
     long remaining = orderService.countByGroupBuyPostIdAndStatusNot(postId, OrderStatus.DELIVERED);
 
-    // 3) 남은 주문이 0개 -> GroupBuyPostStatus도 배송완료로 변경
+    // 3 남은 주문이 0개 -> GroupBuyPostStatus도 배송완료로 변경
     if (remaining == 0) {
       GroupBuyPost post = order.getGroupBuyPost();
 
@@ -117,7 +117,7 @@ public class ParticipationService {
       case SHIPPED -> GroupBuyPostStatus.SHIPPING.name();
       case DELIVERED -> GroupBuyPostStatus.DELIVERED.name();
 
-      // (방어) 데이터가 꼬여서 RECRUITING이 내려오면 RECRUITING 그대로 반환
+      // 데이터가 꼬여 RECRUITING이 내려오는 경우, RECRUITING 그대로 반환
       case RECRUITING -> GroupBuyPostStatus.RECRUITING.name();
     };
   }

--- a/src/main/java/org/sopt/poti/domain/participation/service/ParticipationService.java
+++ b/src/main/java/org/sopt/poti/domain/participation/service/ParticipationService.java
@@ -63,8 +63,7 @@ public class ParticipationService {
 
     // OrderStatus기준 배송중(SHIPPED)일 때만 배송완료 확정 가능
     if (order.getStatus() != OrderStatus.SHIPPED) {
-      throw new BusinessException(
-          ErrorStatus.ORDER_NOT_SHIPPED);
+      throw new BusinessException(ErrorStatus.ORDER_NOT_SHIPPED);
     }
 
     // 1 내 주문 배송완료 처리 (OrderStatus)
@@ -88,7 +87,6 @@ public class ParticipationService {
     return new LeaderUserIdResponse(leaderUserId);
   }
 
-
   // OrderStatus가 DELIVERED면 COMPLETED로 봄
   private boolean isCompleted(OrderStatus status) {
     return status == OrderStatus.DELIVERED;
@@ -105,20 +103,24 @@ public class ParticipationService {
   }
 
   // OrderStatus를 GroupBuyPostStatus처럼 내려줌
-  private String mapToClientPostStatus(OrderStatus orderStatus) {
+  // GroupBuyPostStatus 우선 반영(RECRUITING까지) -> CLOSED 이후에는 OrderStatus 기준
+  private String mapToClientPostStatus(GroupBuyPostStatus postStatus, OrderStatus orderStatus) {
+
+    // 1 분철글이 모집중이면 무조건 RECRUITING 고정
+    if (postStatus == GroupBuyPostStatus.RECRUITING) {
+      return GroupBuyPostStatus.RECRUITING.name();
+    }
+
     return switch (orderStatus) {
-      case RECRUITING -> GroupBuyPostStatus.RECRUITING.name();
-
       case WAIT_PAY, WAIT_PAY_CHECK -> GroupBuyPostStatus.CLOSED.name();
-
       case PAID, READY -> GroupBuyPostStatus.PAYMENT_DONE.name();
-
       case SHIPPED -> GroupBuyPostStatus.SHIPPING.name();
-
       case DELIVERED -> GroupBuyPostStatus.DELIVERED.name();
+
+      // (방어) 데이터가 꼬여서 RECRUITING이 내려오면 RECRUITING 그대로 반환
+      case RECRUITING -> GroupBuyPostStatus.RECRUITING.name();
     };
   }
-
 
   // 응답 Status를 OrderStatus로 내려줌
   private ParticipationListResponse toResponse(Order order) {
@@ -130,7 +132,7 @@ public class ParticipationService {
         post.getArtist().getName(),
         post.getTitle(),
         post.getRepresentativeImageUrl(),
-        mapToClientPostStatus(order.getStatus())
+        mapToClientPostStatus(post.getStatus(), order.getStatus())
     );
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #199 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 그냥 OrderStatus 따라서 COMPLETED 뜨던걸, GroupBuyPostStatus가 RECRUTING이면 그걸 우선적으로 따르도록 변경했습니닼

## 📸 테스트 증명 (필수) 

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [x] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 배송 완료 상태 확인 검증 강화로 부정확한 작업 방지
  * 주문 상태 매핑 로직 개선으로 사용자에게 표시되는 상태 정확도 향상
  * 배송 완료 처리 시 남은 미배송 주문 없음을 확인하는 제어 흐름 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->