### PR TITLE
[FEAT] dev/prod 인프라 및 CD 파이프라인 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD (JIB 이미지 & 무중단 배포)
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "develop", "main" ]
     paths:
       - 'src/**'
       - 'build.gradle'
@@ -10,11 +10,8 @@ on:
       - 'docker-compose*.yml'
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    concurrency:
-      group: deploy-production
-      cancel-in-progress: false # true면 실행 중인 배포 취소, false면 대기 (순차 실행)
     steps:
       - uses: actions/checkout@v4
 
@@ -33,13 +30,24 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
+  deploy-dev:
+    needs: build
+    if: github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    environment: dev
+    concurrency:
+      group: deploy-dev
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
       - name: 배포 파일 전송
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_KEY }}
-          source: "deploy.sh, docker-compose.yml"
+          source: "deploy.sh,docker-compose.yml"
           target: "/home/ubuntu/app"
 
       - name: 배포 파일 검증
@@ -54,7 +62,50 @@ jobs:
               exit 1
             fi
 
-      - name: 배포 스크립트 실행 (SSH)
+      - name: 배포 스크립트 실행
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            cd ~/app
+            chmod +x deploy.sh
+            ./deploy.sh
+
+  deploy-prod:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: prod
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 배포 파일 전송
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          source: "deploy.sh,docker-compose.yml"
+          target: "/home/ubuntu/app"
+
+      - name: 배포 파일 검증
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            if [ ! -f ~/app/deploy.sh ] || [ ! -f ~/app/docker-compose.yml ]; then
+              echo "배포 파일 전송 실패"
+              exit 1
+            fi
+
+      - name: 배포 스크립트 실행
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_HOST }}

--- a/docker-compose-infra-dev.yml
+++ b/docker-compose-infra-dev.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: poti
+      MYSQL_ROOT_HOST: '%'
+      TZ: Asia/Seoul
+    expose:
+      - "3306"
+    volumes:
+      - ./mysql_data:/var/lib/mysql
+    networks:
+      - poti-net
+    restart: always
+
+  redis:
+    image: redis:alpine
+    container_name: redis
+    command: >
+      redis-server
+      --maxmemory 100mb
+      --maxmemory-policy allkeys-lru
+    expose:
+      - "6379"
+    volumes:
+      - ./redis_data:/data
+    networks:
+      - poti-net
+    restart: always
+
+  dozzle:
+    image: amir20/dozzle:latest
+    container_name: dozzle
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "8888:8080"
+    env_file:
+      - .env
+    environment:
+      DOZZLE_USERNAME: ${DOZZLE_USER}
+      DOZZLE_PASSWORD: ${DOZZLE_PW}
+
+networks:
+  poti-net:
+    name: poti-net
+    driver: bridge


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈를 적어주세요. -->
- close #206 

## ✨ 변경 사항
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- DEV/PROD 배포 환경 분리 (develop → DEV EC2, main → PROD EC2)
- GitHub Environments(dev/prod) 기반 CD 파이프라인 구성
- DEV용 인프라 파일 추가 (docker-compose-infra-dev.yml): MySQL + Redis + Dozzle
- PROD는 RDS 사용, DEV는 EC2 로컬 MySQL 사용

## 📸 테스트 증명 (필수) 

## 📚 리뷰어 참고 사항
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 

## ✅ 체크리스트
- [x] 브랜치 전략(git flow)을 따랐나요? (develop -> feat/...)
- [ ] 로컬에서 빌드 및 실행이 정상적으로 되나요?
- [x] 불필요한 주석(TODO 등)이나 더미 코드는 제거했나요?
- [x] 컨벤션(커밋 메시지, 코드 스타일)을 지켰나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 개발/운영 환경별로 자동 배포가 분리되어, 브랜치에 따라 적절한 환경으로 배포됩니다.
  * 개발용 인프라 구성이 추가되어 데이터베이스, 캐시, 로그 모니터링 도구를 한 번에 실행할 수 있습니다.

* **버그 수정**
  * 배포 전 원격 파일 확인 절차가 추가되어, 누락된 배포 파일로 인한 실패를 줄였습니다.
  * 배포 실행 흐름이 정리되어 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->